### PR TITLE
refactor: Update forwarding configuration format

### DIFF
--- a/docs/config/proxy-integration.md
+++ b/docs/config/proxy-integration.md
@@ -11,36 +11,46 @@ Velocity Modern Forwarding is a method of forwarding player connections using th
 
 :::code-group
 ```toml [server.toml] {2-3}
-[forwarding.velocity]
-enabled = true
+[forwarding]
+method = "MODERN"
 secret = "<your-secret>"
 ```
 :::
 
 Replace `<your-secret>` with the forwarding secret of your Velocity proxy.
 
-## BungeeCord Legacy Forwarding
-
-BungeeCord Legacy Forwarding is a method of forwarding player connections using the BungeeCord proxy. To enable BungeeCord forwarding, set the following configuration options:
-
-:::code-group
-```toml [server.toml] {2}
-[forwarding.bungee_cord]
-enabled = true
-```
-:::
-
 ## BungeeGuard Authentication
 
-BungeeGuard and BungeeGuardPlus are additional security features for BungeeCord that provide token-based authentication for incoming player connections. To enable BungeeGuard authentication, set the following configuration options:
+BungeeGuard is an additional security feature that provide token-based authentication for incoming player connections. To enable BungeeGuard authentication, set the following configuration options:
 
 :::code-group
-```toml [server.toml] {3-5}
-[forwarding.bungee_cord]
-enabled = true
-bungee_guard = true
+```toml [server.toml] {2-3}
+[forwarding]
+method = "BUNGEE_GUARD"
 tokens = ["<token1>", "<token2>", ...]
 ```
 :::
 
 Replace `<token1>`, `<token2>`, etc., with valid BungeeGuard tokens for your BungeeCord proxy.
+
+## BungeeCord Legacy Forwarding
+
+To enable BungeeCord forwarding, set the following configuration options:
+
+:::code-group
+```toml [server.toml] {2}
+[forwarding]
+method = "LEGACY"
+```
+:::
+
+## None
+
+To disable forwarding altogether:
+
+:::code-group
+```toml [server.toml] {2}
+[forwarding]
+method = "NONE"
+```
+:::

--- a/pico_limbo/src/configuration/forwarding.rs
+++ b/pico_limbo/src/configuration/forwarding.rs
@@ -2,19 +2,74 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct ModernForwardingConfig {
-    pub enabled: bool,
-    pub secret: String,
+    enabled: bool,
+    secret: String,
 }
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct BungeeCordForwardingConfig {
-    pub enabled: bool,
-    pub bungee_guard: bool,
-    pub tokens: Vec<String>,
+    enabled: bool,
+    bungee_guard: bool,
+    tokens: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Default)]
-pub struct ForwardingConfig {
-    pub velocity: ModernForwardingConfig,
-    pub bungee_cord: BungeeCordForwardingConfig,
+pub struct StructuredForwarding {
+    velocity: ModernForwardingConfig,
+    bungee_cord: BungeeCordForwardingConfig,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+#[serde(tag = "method", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TaggedForwarding {
+    #[default]
+    #[serde(alias = "none")]
+    None,
+
+    #[serde(alias = "legacy")]
+    Legacy,
+
+    #[serde(alias = "bungee_guard")]
+    BungeeGuard { tokens: Vec<String> },
+
+    #[serde(alias = "modern")]
+    Modern { secret: String },
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ForwardingConfig {
+    Structured(StructuredForwarding),
+    Tagged(TaggedForwarding),
+}
+
+impl Default for ForwardingConfig {
+    fn default() -> Self {
+        Self::Tagged(TaggedForwarding::default())
+    }
+}
+
+impl From<ForwardingConfig> for TaggedForwarding {
+    fn from(cfg: ForwardingConfig) -> Self {
+        match cfg {
+            ForwardingConfig::Tagged(forwarding) => forwarding,
+            ForwardingConfig::Structured(forwarding) => {
+                if forwarding.velocity.enabled {
+                    Self::Modern {
+                        secret: forwarding.velocity.secret,
+                    }
+                } else if forwarding.bungee_cord.enabled {
+                    if forwarding.bungee_cord.bungee_guard {
+                        Self::BungeeGuard {
+                            tokens: forwarding.bungee_cord.tokens,
+                        }
+                    } else {
+                        Self::Legacy
+                    }
+                } else {
+                    Self::None
+                }
+            }
+        }
+    }
 }

--- a/pico_limbo/src/configuration/mod.rs
+++ b/pico_limbo/src/configuration/mod.rs
@@ -3,3 +3,5 @@ mod forwarding;
 mod game_mode_config;
 mod server_list;
 mod world_config;
+
+pub use forwarding::TaggedForwarding;


### PR DESCRIPTION
New format for the forwarding configuration with backward compatibility:

```toml
[forwarding]
# can also be "MODERN", "LEGACY" or "BUNGEEGUARD"
method = "NONE"
# only used when using modern forwarding method, otherwise it'll be ignored
secret = "<your-secret>"
# only used when using bungee_guard forwarding method, otherwise it'll be ignored
tokens = ["<token1>", "<token2>"]
```

The previous format is still supported but may be removed later.