### PR TITLE
Fix SetSubtitleText packet type in packet_registry.rs

### DIFF
--- a/pico_limbo/src/handlers/configuration.rs
+++ b/pico_limbo/src/handlers/configuration.rs
@@ -23,6 +23,7 @@ use minecraft_packets::play::set_action_bar_text_packet::SetActionBarTextPacket;
 use minecraft_packets::play::set_chunk_cache_center_packet::SetCenterChunkPacket;
 use minecraft_packets::play::set_default_spawn_position_packet::SetDefaultSpawnPositionPacket;
 use minecraft_packets::play::set_entity_data_packet::SetEntityMetadataPacket;
+use minecraft_packets::play::set_subtitle_text_packet::SetSubtitleTextPacket;
 use minecraft_packets::play::set_title_text_packet::SetTitleTextPacket;
 use minecraft_packets::play::set_titles_animation::SetTitlesAnimationPacket;
 use minecraft_packets::play::synchronize_player_position_packet::SynchronizePlayerPositionPacket;
@@ -284,13 +285,13 @@ fn send_title_text_packets(
                     batch.queue(|| PacketRegistry::SetTitleText(title_packet));
                 }
                 TitleType::Subtitle(subtitle) => {
-                    let subtitle_packet = SetTitleTextPacket::new(subtitle);
+                    let subtitle_packet = SetSubtitleTextPacket::new(subtitle);
                     batch.queue(|| PacketRegistry::SetSubtitleText(subtitle_packet));
                 }
                 TitleType::Both { title, subtitle } => {
                     let title_packet = SetTitleTextPacket::new(title);
                     batch.queue(|| PacketRegistry::SetTitleText(title_packet));
-                    let subtitle_packet = SetTitleTextPacket::new(subtitle);
+                    let subtitle_packet = SetSubtitleTextPacket::new(subtitle);
                     batch.queue(|| PacketRegistry::SetSubtitleText(subtitle_packet));
                 }
             }

--- a/pico_limbo/src/server/packet_registry.rs
+++ b/pico_limbo/src/server/packet_registry.rs
@@ -38,6 +38,7 @@ use minecraft_packets::play::set_default_spawn_position_packet::SetDefaultSpawnP
 use minecraft_packets::play::set_entity_data_packet::SetEntityMetadataPacket;
 use minecraft_packets::play::set_player_position_and_rotation_packet::SetPlayerPositionAndRotationPacket;
 use minecraft_packets::play::set_player_position_packet::SetPlayerPositionPacket;
+use minecraft_packets::play::set_subtitle_text_packet::SetSubtitleTextPacket;
 use minecraft_packets::play::set_title_text_packet::SetTitleTextPacket;
 use minecraft_packets::play::set_titles_animation::SetTitlesAnimationPacket;
 use minecraft_packets::play::synchronize_player_position_packet::SynchronizePlayerPositionPacket;
@@ -310,7 +311,7 @@ pub enum PacketRegistry {
         bound = "clientbound",
         name = "minecraft:set_subtitle_text"
     )]
-    SetSubtitleText(SetTitleTextPacket),
+    SetSubtitleText(SetSubtitleTextPacket),
 
     #[protocol_id(
         state = "play",


### PR DESCRIPTION
Replace `SetTitleTextPacket` with `SetSubtitleTextPacket` for the `minecraft:set_subtitle_text` clientbound play packet