### PR TITLE
fix: Do not send registry data starting 1.21.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Do not send registry data starting 1.21.5, this should fix issues with PacketEvents some users were having
+
 ## [1.12.2+mc26.1.2] - 2026-04-12
 
 ### Fixed

--- a/crates/minecraft_packets/src/configuration/data/registry_entry.rs
+++ b/crates/minecraft_packets/src/configuration/data/registry_entry.rs
@@ -4,15 +4,16 @@ use std::borrow::Cow;
 #[derive(PacketOut)]
 pub struct RegistryEntry {
     entry_id: Identifier,
-    /// Entry data
+    /// Entry data. If omitted, sourced from the selected known packs.
     nbt_bytes: Optional<Cow<'static, [u8]>>,
 }
 
 impl RegistryEntry {
-    pub fn new(entry_id: Identifier, nbt_bytes: Cow<'static, [u8]>) -> Self {
+    /// nbt_bytes should be none starting 1.21.5 (included)
+    pub fn new(entry_id: Identifier, nbt_bytes: Option<Cow<'static, [u8]>>) -> Self {
         Self {
             entry_id,
-            nbt_bytes: Optional::Some(nbt_bytes),
+            nbt_bytes: Optional::from(nbt_bytes),
         }
     }
 }

--- a/crates/minecraft_packets/src/configuration/registry_data_packet.rs
+++ b/crates/minecraft_packets/src/configuration/registry_data_packet.rs
@@ -14,6 +14,7 @@ pub struct RegistryDataPacket {
 }
 
 impl RegistryDataPacket {
+    /// Since 1.20.2 until 1.20.4 (included)
     pub fn codec(registry_codec_bytes: Cow<'static, [u8]>) -> Self {
         Self {
             registry_id: Omitted::None,
@@ -22,6 +23,7 @@ impl RegistryDataPacket {
         }
     }
 
+    /// Since 1.20.5 (included)
     pub fn registry(registry_id: Identifier, entries: Vec<RegistryEntry>) -> Self {
         Self {
             registry_id: Omitted::Some(registry_id),

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -55,6 +55,7 @@ fn send_configuration_packets(
     }
 
     // Send tags
+    // TODO: Move tags after registry data to match vanilla's behavior
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_21_6) {
         // Since 1.21.6, the Dialog tags should be sent to have server links working
         // Since 1.21.11, the Timeline tags should be sent to get the time of day working
@@ -86,18 +87,24 @@ fn send_configuration_packets(
 
     // Send Registry Data
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_5) {
+        let has_registry_data = protocol_version.is_before_inclusive(ProtocolVersion::V1_21_4);
         // Since 1.20.5, each registry is sent in its own packet
         batch.chain_iter(
             registry_provider
                 .get_registry_data_v1_20_5()?
                 .into_iter()
-                .map(|(registry_id, registry_entries)| {
+                .map(move |(registry_id, registry_entries)| {
                     let packet = RegistryDataPacket::registry(
                         registry_id,
                         registry_entries
                             .iter()
                             .map(|entry| {
-                                RegistryEntry::new(entry.entry_id.clone(), entry.nbt_bytes.clone())
+                                let nbt_bytes = if has_registry_data {
+                                    Some(entry.nbt_bytes.clone())
+                                } else {
+                                    None
+                                };
+                                RegistryEntry::new(entry.entry_id.clone(), nbt_bytes)
                             })
                             .collect(),
                     );


### PR DESCRIPTION
The vanilla game is able to load registries data from the client game files.

This should fix the following issue from PacketEvents: retrooper/packetevents#1482

This PR has been tested against 1.20 - 26.1 with PacketEvents on Velocity and direct connection without a proxy.

Please feel free to build PicoLimbo locally and provide any feedback. I can provide dev builds on [my Discord server](https://discord.gg/M2a9dxJPRy).