### PR TITLE
Fix/registry and keep alive config phase

### DIFF
--- a/crates/minecraft_packets/src/configuration/data/known_pack.rs
+++ b/crates/minecraft_packets/src/configuration/data/known_pack.rs
@@ -2,9 +2,9 @@ use minecraft_protocol::prelude::*;
 
 #[derive(PacketIn, PacketOut)]
 pub struct KnownPack {
-    namespace: String,
-    id: String,
-    version: String,
+    pub namespace: String,
+    pub id: String,
+    pub version: String,
 }
 
 impl KnownPack {

--- a/crates/minecraft_packets/src/configuration/mod.rs
+++ b/crates/minecraft_packets/src/configuration/mod.rs
@@ -4,4 +4,5 @@ pub mod configuration_client_bound_plugin_message_packet;
 pub mod data;
 pub mod finish_configuration_packet;
 pub mod registry_data_packet;
+pub mod server_bound_known_packs_packet;
 pub mod update_tags_packet;

--- a/crates/minecraft_packets/src/configuration/server_bound_known_packs_packet.rs
+++ b/crates/minecraft_packets/src/configuration/server_bound_known_packs_packet.rs
@@ -1,0 +1,11 @@
+use crate::configuration::data::known_pack::KnownPack;
+use minecraft_protocol::prelude::*;
+
+/// Sent by the client in response to `ClientBoundKnownPacksPacket`. Lists the
+/// known packs the client accepts (i.e. that the client has locally). The
+/// server can use this to decide whether to send full registry data or rely on
+/// the client's bundled vanilla data.
+#[derive(PacketIn)]
+pub struct ServerBoundKnownPacksPacket {
+    pub known_packs: LengthPaddedVec<KnownPack>,
+}

--- a/pico_libraries/pico_nbt/src/json.rs
+++ b/pico_libraries/pico_nbt/src/json.rs
@@ -1,14 +1,7 @@
 use crate::{Error, Result, Value};
 use serde_json::Value as JsonValue;
 
-/// Converts a JSON value to an NBT value.
-///
-/// # Errors
-/// Returns an error if:
-/// * The JSON contains a `null` value, which is not supported in NBT.
-/// * A number is invalid or cannot be represented in NBT types.
-/// * Array elements cannot be converted to NBT values.
-fn convert_array(arr: Vec<JsonValue>) -> Result<Value> {
+fn convert_array(arr: Vec<JsonValue>, options: crate::NbtOptions) -> Result<Value> {
     if arr.is_empty() {
         return Ok(Value::List(Vec::new()));
     }
@@ -44,7 +37,10 @@ fn convert_array(arr: Vec<JsonValue>) -> Result<Value> {
         }
     }
 
-    if is_byte {
+    // When numeric_widening is enabled, never emit ByteArray for integer arrays —
+    // Mojang/NumberOps emits IntArray (or LongArray on overflow). ByteArray remains
+    // possible only via the default (non-widening) code path.
+    if is_byte && !options.is_numeric_widening() {
         let mut bytes = Vec::with_capacity(arr.len());
         for elem in arr {
             if let JsonValue::Number(n) = elem {
@@ -85,12 +81,12 @@ fn convert_array(arr: Vec<JsonValue>) -> Result<Value> {
 
     let mut list = Vec::with_capacity(arr.len());
     for elem in arr {
-        list.push(json_to_nbt(elem)?);
+        list.push(json_to_nbt_with_options(elem, options)?);
     }
     Ok(Value::List(list))
 }
 
-/// Converts a JSON value to an NBT value.
+/// Converts a JSON value to an NBT value using default options.
 ///
 /// # Errors
 /// Returns an error if:
@@ -98,50 +94,71 @@ fn convert_array(arr: Vec<JsonValue>) -> Result<Value> {
 /// * A number is invalid or cannot be represented in NBT types.
 /// * Array elements cannot be converted to NBT values.
 pub fn json_to_nbt(json: JsonValue) -> Result<Value> {
+    json_to_nbt_with_options(json, crate::NbtOptions::new())
+}
+
+/// Converts a JSON value to an NBT value with caller-supplied options.
+///
+/// When `options.is_numeric_widening()` is true, integer JSON numbers are encoded
+/// as `Value::Int` if they fit in `i32`, `Value::Long` otherwise — matching
+/// Mojang's canonical NBT representation. Floating-point numbers are encoded as
+/// `Value::Float` (32-bit) always, even when precision is lost. Booleans
+/// (`JsonValue::Bool`) remain `Value::Byte(0/1)`. With the flag off, behavior is
+/// the legacy smallest-fitting downcast (`Byte` / `Short` / `Int` / `Long`,
+/// `Float` only when exact, `Double` otherwise).
+///
+/// # Errors
+/// Returns an error if:
+/// * The JSON contains a `null` value, which is not supported in NBT.
+/// * A number is invalid or cannot be represented in NBT types.
+/// * Array elements cannot be converted to NBT values.
+pub fn json_to_nbt_with_options(json: JsonValue, options: crate::NbtOptions) -> Result<Value> {
     match json {
         JsonValue::Null => Err(Error::Message("JSON null is not supported in NBT".into())),
         JsonValue::Bool(b) => Ok(Value::Byte(i8::from(b))),
-        JsonValue::Number(n) => n.as_i64().map_or_else(
-            || {
-                n.as_f64().map_or_else(
-                    || Err(Error::Message("Invalid JSON number".into())),
-                    |f| {
-                        #[allow(clippy::cast_possible_truncation)]
-                        // I cannot find a better solution than casting the double down to float
-                        let f32_val = f as f32;
-                        if (f64::from(f32_val) - f).abs() < f64::EPSILON {
-                            Ok(Value::Float(f32_val))
-                        } else {
-                            Ok(Value::Double(f))
-                        }
-                    },
-                )
-            },
-            |i| {
-                i8::try_from(i).map_or_else(
-                    |_| {
-                        i16::try_from(i).map_or_else(
-                            |_| {
-                                i32::try_from(i)
-                                    .map_or_else(|_| Ok(Value::Long(i)), |int| Ok(Value::Int(int)))
-                            },
-                            |s| Ok(Value::Short(s)),
-                        )
-                    },
-                    |s| Ok(Value::Byte(s)),
-                )
-            },
-        ),
+        JsonValue::Number(n) => convert_number(&n, options),
         JsonValue::String(s) => Ok(Value::String(s)),
-        JsonValue::Array(arr) => convert_array(arr),
+        JsonValue::Array(arr) => convert_array(arr, options),
         JsonValue::Object(obj) => {
             let mut map = indexmap::IndexMap::new();
             for (k, v) in obj {
-                map.insert(k, json_to_nbt(v)?);
+                map.insert(k, json_to_nbt_with_options(v, options)?);
             }
             Ok(Value::Compound(map))
         }
     }
+}
+
+fn convert_number(n: &serde_json::Number, options: crate::NbtOptions) -> Result<Value> {
+    if let Some(i) = n.as_i64() {
+        if options.is_numeric_widening() {
+            return Ok(i32::try_from(i).map_or(Value::Long(i), Value::Int));
+        }
+        // Legacy: smallest-fitting type.
+        return Ok(i8::try_from(i).map_or_else(
+            |_| {
+                i16::try_from(i).map_or_else(
+                    |_| i32::try_from(i).map_or(Value::Long(i), Value::Int),
+                    Value::Short,
+                )
+            },
+            Value::Byte,
+        ));
+    }
+    if let Some(f) = n.as_f64() {
+        #[allow(clippy::cast_possible_truncation)]
+        let f32_val = f as f32;
+        if options.is_numeric_widening() {
+            // Mojang's registry codecs expect Float strictly, even at the cost of
+            // precision (e.g. cubic_bezier ease curves in minecraft:timeline).
+            return Ok(Value::Float(f32_val));
+        }
+        if (f64::from(f32_val) - f).abs() < f64::EPSILON {
+            return Ok(Value::Float(f32_val));
+        }
+        return Ok(Value::Double(f));
+    }
+    Err(Error::Message("Invalid JSON number".into()))
 }
 
 #[cfg(test)]
@@ -313,5 +330,160 @@ mod tests {
     fn test_json_null_error() {
         let res = json_to_nbt(json!(null));
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn widening_zero_becomes_int() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(0), opts).unwrap(),
+            Value::Int(0),
+        );
+    }
+
+    #[test]
+    fn widening_short_range_becomes_int() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(1_000), opts).unwrap(),
+            Value::Int(1_000),
+        );
+    }
+
+    #[test]
+    fn widening_int_max_becomes_int() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(i32::MAX), opts).unwrap(),
+            Value::Int(i32::MAX),
+        );
+    }
+
+    #[test]
+    fn widening_overflow_becomes_long() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        let big: i64 = i64::from(i32::MAX) + 1;
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(big), opts).unwrap(),
+            Value::Long(big),
+        );
+    }
+
+    #[test]
+    fn widening_negative_short_range_becomes_int() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(-1_000), opts).unwrap(),
+            Value::Int(-1_000),
+        );
+    }
+
+    #[test]
+    fn widening_bool_stays_byte() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(true), opts).unwrap(),
+            Value::Byte(1),
+        );
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(false), opts).unwrap(),
+            Value::Byte(0),
+        );
+    }
+
+    #[test]
+    fn widening_float_unchanged_when_exact() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(1.0_f64), opts).unwrap(),
+            Value::Float(1.0),
+        );
+    }
+
+    #[test]
+    fn widening_imprecise_double_collapses_to_float() {
+        // 0.362 cannot round-trip exactly between f64 and f32. Without widening,
+        // the legacy code keeps it as Double to preserve precision. With widening
+        // enabled, it must collapse to Float — Mojang's registry codecs expect
+        // Float strictly (e.g. cubic_bezier values in minecraft:timeline).
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        let result =
+            crate::json::json_to_nbt_with_options(json!(0.362_f64), opts).unwrap();
+        let Value::Float(f) = result else {
+            panic!("expected Float under widening, got {result:?}");
+        };
+        assert!(
+            (f - 0.362_f32).abs() < f32::EPSILON,
+            "expected ~0.362 as Float, got {f}",
+        );
+    }
+
+    #[test]
+    fn default_options_keep_downcasting() {
+        let opts = crate::NbtOptions::new();
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(0), opts).unwrap(),
+            Value::Byte(0),
+        );
+        assert_eq!(
+            crate::json::json_to_nbt_with_options(json!(128), opts).unwrap(),
+            Value::Short(128),
+        );
+    }
+
+    #[test]
+    fn default_options_keep_double_when_imprecise() {
+        let opts = crate::NbtOptions::new();
+        let result =
+            crate::json::json_to_nbt_with_options(json!(0.362_f64), opts).unwrap();
+        assert!(
+            matches!(result, Value::Double(d) if (d - 0.362_f64).abs() < f64::EPSILON),
+            "expected Double under default options, got {result:?}",
+        );
+    }
+
+    #[test]
+    fn nested_compound_widens_recursively() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        let json_obj = json!({"ticks": 18000, "show_in_commands": true});
+        let nbt = crate::json::json_to_nbt_with_options(json_obj, opts).unwrap();
+        let Value::Compound(map) = nbt else {
+            panic!("Expected Compound");
+        };
+        assert_eq!(map.get("ticks"), Some(&Value::Int(18000)));
+        assert_eq!(map.get("show_in_commands"), Some(&Value::Byte(1)));
+    }
+
+    #[test]
+    fn widening_byte_range_array_becomes_int_array() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        let nbt = crate::json::json_to_nbt_with_options(json!([1, 2, 3]), opts).unwrap();
+        assert_eq!(nbt, Value::IntArray(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn widening_short_range_array_becomes_int_array() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        let nbt =
+            crate::json::json_to_nbt_with_options(json!([1000, 2000, 3000]), opts).unwrap();
+        assert_eq!(nbt, Value::IntArray(vec![1000, 2000, 3000]));
+    }
+
+    #[test]
+    fn widening_overflow_array_becomes_long_array() {
+        let opts = crate::NbtOptions::new().numeric_widening(true);
+        let big: i64 = i64::from(i32::MAX) + 1;
+        let nbt = crate::json::json_to_nbt_with_options(json!([big, big]), opts).unwrap();
+        assert_eq!(nbt, Value::LongArray(vec![big, big]));
+    }
+
+    #[test]
+    fn default_byte_range_array_stays_byte_array() {
+        let opts = crate::NbtOptions::new();
+        let nbt = crate::json::json_to_nbt_with_options(json!([1, 2, 3]), opts).unwrap();
+        let Value::ByteArray(bytes) = nbt else {
+            panic!("expected ByteArray with default options, got {nbt:?}");
+        };
+        assert_eq!(bytes, vec![1, 2, 3]);
     }
 }

--- a/pico_libraries/pico_nbt/src/lib.rs
+++ b/pico_libraries/pico_nbt/src/lib.rs
@@ -12,7 +12,7 @@ pub use de::from_value;
 pub use error::{Error, Result};
 pub use indexmap::IndexMap;
 pub use io::{CompressionType, decode, encode};
-pub use json::json_to_nbt;
+pub use json::{json_to_nbt, json_to_nbt_with_options};
 pub use options::NbtOptions;
 pub use reader::{
     from_file, from_file_struct, from_path, from_path_struct, from_path_with_options, from_reader,

--- a/pico_libraries/pico_nbt/src/options.rs
+++ b/pico_libraries/pico_nbt/src/options.rs
@@ -6,6 +6,7 @@ pub struct NbtOptions {
 
 const NAMELESS_ROOT: u8 = 1 << 0;
 const DYNAMIC_LISTS: u8 = 1 << 1;
+const NUMERIC_WIDENING: u8 = 1 << 2;
 
 impl NbtOptions {
     /// Creates a new `NbtOptions` with default settings.
@@ -43,6 +44,25 @@ impl NbtOptions {
         self
     }
 
+    /// Sets whether integer JSON numbers should be widened to canonical NBT types
+    /// (`Int` for values fitting i32, `Long` otherwise) and floating-point numbers
+    /// should always be encoded as `Float` (32-bit), instead of being downcast to
+    /// the smallest-fitting NBT type. Booleans (`JsonValue::Bool`) are unaffected
+    /// and remain `Value::Byte(0/1)`.
+    ///
+    /// This flag matches the NBT serialization Mojang's vanilla server emits for
+    /// registry data, and is required to satisfy strict codecs such as
+    /// `PacketEvents`' `minecraft:timeline` decoder.
+    #[must_use]
+    pub const fn numeric_widening(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.flags |= NUMERIC_WIDENING;
+        } else {
+            self.flags &= !NUMERIC_WIDENING;
+        }
+        self
+    }
+
     /// Checks if nameless root is enabled.
     #[must_use]
     pub const fn is_nameless_root(&self) -> bool {
@@ -53,5 +73,44 @@ impl NbtOptions {
     #[must_use]
     pub const fn is_dynamic_lists(&self) -> bool {
         (self.flags & DYNAMIC_LISTS) != 0
+    }
+
+    /// Checks if numeric widening is enabled.
+    #[must_use]
+    pub const fn is_numeric_widening(&self) -> bool {
+        (self.flags & NUMERIC_WIDENING) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numeric_widening_default_is_false() {
+        assert!(!NbtOptions::new().is_numeric_widening());
+    }
+
+    #[test]
+    fn numeric_widening_can_be_enabled() {
+        let opts = NbtOptions::new().numeric_widening(true);
+        assert!(opts.is_numeric_widening());
+    }
+
+    #[test]
+    fn numeric_widening_can_be_disabled() {
+        let opts = NbtOptions::new().numeric_widening(true).numeric_widening(false);
+        assert!(!opts.is_numeric_widening());
+    }
+
+    #[test]
+    fn numeric_widening_does_not_collide_with_other_flags() {
+        let opts = NbtOptions::new()
+            .nameless_root(true)
+            .dynamic_lists(true)
+            .numeric_widening(true);
+        assert!(opts.is_nameless_root());
+        assert!(opts.is_dynamic_lists());
+        assert!(opts.is_numeric_widening());
     }
 }

--- a/pico_libraries/pico_registries/src/data/registry.rs
+++ b/pico_libraries/pico_registries/src/data/registry.rs
@@ -106,7 +106,10 @@ impl Registry {
                 };
                 let json_data = serde_json::from_str(&json_str)?;
 
-                let nbt_value = pico_nbt::json_to_nbt(json_data)?;
+                let nbt_value = pico_nbt::json_to_nbt_with_options(
+                    json_data,
+                    pico_nbt::NbtOptions::new().numeric_widening(true),
+                )?;
 
                 let entry = RegistryEntry::new(value, nbt_value, registry_key, protocol_id);
                 protocol_id += 1;

--- a/pico_libraries/pico_registries/tests/registry_widening.rs
+++ b/pico_libraries/pico_registries/tests/registry_widening.rs
@@ -1,0 +1,119 @@
+//! Integration test ensuring registry JSON files load with canonical NBT integer
+//! tags (Int/Long) and Float (32-bit) floats when numeric widening is enabled —
+//! required for MC 1.21.11+ clients and strict third-party codecs
+//! (e.g. `PacketEvents`).
+
+use pico_nbt::Value;
+use pico_registries::{Identifier, Registry, RegistryKeys};
+use std::path::PathBuf;
+
+fn data_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at pico_libraries/pico_registries/.
+    // The on-disk layout is data/generated/<VERSION>/data/minecraft/<registry>/<entry>.json,
+    // and Registry::load joins "<namespace>/<thing>" onto its resource_path,
+    // so we pass <repo>/data/generated/V26_1/data here.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../data/generated/V26_1/data")
+}
+
+#[test]
+#[allow(clippy::manual_assert)] // pico_registries' clippy.toml forbids std::assert.
+fn timeline_day_emits_canonical_int_and_float_tags() {
+    let registry = Registry::load(&RegistryKeys::Timeline, &data_root())
+        .expect("V26_1 timeline registry must load");
+
+    let day_id = Identifier::vanilla_unchecked("day");
+    let day_entry = registry.try_get(&day_id).expect("timeline/day must exist");
+
+    let Value::Compound(root) = day_entry.get_raw_value() else {
+        panic!(
+            "expected timeline/day root to be a Compound, got {:?}",
+            day_entry.get_raw_value()
+        );
+    };
+
+    // period_ticks must be Int(24000), not Short(24000).
+    let period_ticks = root
+        .get("period_ticks")
+        .expect("timeline/day must have period_ticks");
+    assert_eq!(
+        *period_ticks,
+        Value::Int(24_000),
+        "expected period_ticks: Int(24000), got {period_ticks:?}",
+    );
+
+    // time_markers.minecraft:wake_up_from_sleep is the bare scalar `0` — without
+    // widening it would be Byte(0).
+    let Value::Compound(time_markers) = root
+        .get("time_markers")
+        .expect("timeline/day must have time_markers")
+    else {
+        panic!("expected time_markers to be a Compound");
+    };
+    let wake_up = time_markers
+        .get("minecraft:wake_up_from_sleep")
+        .expect("time_markers must contain wake_up_from_sleep");
+    assert_eq!(
+        *wake_up,
+        Value::Int(0),
+        "expected wake_up_from_sleep: Int(0), got {wake_up:?}",
+    );
+
+    // time_markers.minecraft:day.ticks must be Int(1000), not Short(1000).
+    let Value::Compound(day_marker) = time_markers
+        .get("minecraft:day")
+        .expect("time_markers must contain minecraft:day")
+    else {
+        panic!("expected time_markers.minecraft:day to be a Compound");
+    };
+    let day_ticks = day_marker
+        .get("ticks")
+        .expect("time_markers.minecraft:day must have ticks");
+    assert_eq!(
+        *day_ticks,
+        Value::Int(1_000),
+        "expected day.ticks: Int(1000), got {day_ticks:?}",
+    );
+
+    // show_in_commands is a JSON boolean — must remain Byte(1).
+    let show = day_marker
+        .get("show_in_commands")
+        .expect("day must have show_in_commands");
+    assert_eq!(
+        *show,
+        Value::Byte(1),
+        "expected show_in_commands: Byte(1) (boolean), got {show:?}",
+    );
+
+    // tracks.minecraft:visual/moon_angle.ease.cubic_bezier[0] is ~0.362 — must
+    // collapse to Float (lossy) under widening. Without widening the legacy
+    // code keeps it as Double to preserve precision.
+    let Value::Compound(tracks) = root.get("tracks").expect("timeline/day must have tracks")
+    else {
+        panic!("expected tracks to be a Compound");
+    };
+    let Value::Compound(moon_angle) = tracks
+        .get("minecraft:visual/moon_angle")
+        .expect("tracks must contain minecraft:visual/moon_angle")
+    else {
+        panic!("expected minecraft:visual/moon_angle to be a Compound");
+    };
+    let Value::Compound(ease) = moon_angle.get("ease").expect("moon_angle.ease must exist")
+    else {
+        panic!("expected moon_angle.ease to be a Compound");
+    };
+    let Value::List(cubic_bezier) = ease
+        .get("cubic_bezier")
+        .expect("ease.cubic_bezier must exist")
+    else {
+        panic!("expected ease.cubic_bezier to be a List");
+    };
+    let first = cubic_bezier
+        .first()
+        .expect("cubic_bezier list must be non-empty");
+    let Value::Float(f) = first else {
+        panic!("expected cubic_bezier[0] to be Float, got {first:?}");
+    };
+    if (*f - 0.362_f32).abs() >= 0.001 {
+        panic!("expected cubic_bezier[0] ≈ 0.362 (Float), got Float({f})");
+    }
+}

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -37,6 +37,23 @@ impl PacketHandler for LoginAcknowledgedPacket {
     }
 }
 
+/// Returns the exact Mojang pack version string for the `minecraft:core` known
+/// pack that the client expects for a given protocol version. The client compares
+/// this string strictly; sending a less-specific version (e.g. `"26.1"` for a
+/// client running `26.1.2`) causes the client to reject the pack and respond with
+/// an empty `select_known_packs` list, forcing the server to send every registry
+/// instead of letting the client use its bundled vanilla data.
+///
+/// `ProtocolVersion::humanize()` returns `"26.1"` for `V26_1` because that's the
+/// minor name; the actual Mojang release tag is `"26.1.2"`. Any protocol version
+/// whose release tag differs from `humanize()` needs an arm here.
+fn known_pack_version(version: ProtocolVersion) -> &'static str {
+    match version {
+        ProtocolVersion::V26_1 => "26.1.2",
+        _ => version.humanize(),
+    }
+}
+
 /// Only for >= 1.20.2
 fn send_configuration_packets(
     batch: &mut Batch<PacketRegistry>,
@@ -50,7 +67,7 @@ fn send_configuration_packets(
 
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_5) {
         // Send Known Packs
-        let packet = ClientBoundKnownPacksPacket::new(protocol_version.humanize());
+        let packet = ClientBoundKnownPacksPacket::new(known_pack_version(protocol_version));
         batch.queue(|| PacketRegistry::ClientBoundKnownPacks(packet));
     }
 

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -9,6 +9,7 @@ use minecraft_packets::configuration::configuration_client_bound_plugin_message_
 use minecraft_packets::configuration::data::registry_entry::RegistryEntry;
 use minecraft_packets::configuration::finish_configuration_packet::FinishConfigurationPacket;
 use minecraft_packets::configuration::registry_data_packet::RegistryDataPacket;
+use minecraft_packets::configuration::server_bound_known_packs_packet::ServerBoundKnownPacksPacket;
 use minecraft_packets::configuration::update_tags_packet::{
     RegistryTag, TaggedRegistry, UpdateTagsPacket,
 };
@@ -54,29 +55,58 @@ fn known_pack_version(version: ProtocolVersion) -> &'static str {
     }
 }
 
-/// Only for >= 1.20.2
+/// Sends the first phase of the configuration burst for protocols `>= 1.20.2`.
+///
+/// For `>= 1.20.5` this sends only brand + `select_known_packs` and stops, leaving
+/// the rest of the burst (tags, registry data, `FinishConfiguration`) to
+/// `ServerBoundKnownPacksPacket::handle`, which is invoked when the client
+/// responds with its accepted packs. This mirrors Mojang vanilla / Paper: we
+/// don't dump every registry if the client already has them locally, and we
+/// don't transition the client to PLAY prematurely.
+///
+/// For `1.20.2`–`1.20.4` (no known-packs handshake), we send the full burst in
+/// one go since the protocol can't negotiate.
 fn send_configuration_packets(
     batch: &mut Batch<PacketRegistry>,
     protocol_version: ProtocolVersion,
 ) -> Result<(), PacketHandlerError> {
-    let registry_provider = PrecomputedRegistries::new(protocol_version);
-
     // Send Server Brand
     let packet = ConfigurationClientBoundPluginMessagePacket::brand(SERVER_BRAND);
     batch.queue(|| PacketRegistry::ConfigurationClientBoundPluginMessage(packet));
 
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_5) {
-        // Send Known Packs
+        // Send Known Packs and stop. The rest is sent by
+        // ServerBoundKnownPacksPacket::handle once the client responds.
         let packet = ClientBoundKnownPacksPacket::new(known_pack_version(protocol_version));
         batch.queue(|| PacketRegistry::ClientBoundKnownPacks(packet));
+    } else {
+        // Pre-1.20.5: no handshake, send everything now.
+        send_post_known_packs_configuration_packets(batch, protocol_version, false)?;
     }
+
+    Ok(())
+}
+
+/// Sends the configuration packets that follow the optional KnownPacks handshake:
+/// tags (`>= 1.21.6`), registry data (unless the client accepted vanilla), and
+/// `FinishConfiguration`.
+///
+/// `client_accepted_vanilla_core` indicates whether the client accepted the
+/// `minecraft:core` known pack we offered. When true, the client already has all
+/// vanilla registry data locally and we skip sending it — matching Mojang
+/// vanilla / Paper behavior. When false (or pre-1.20.5), we send every registry.
+fn send_post_known_packs_configuration_packets(
+    batch: &mut Batch<PacketRegistry>,
+    protocol_version: ProtocolVersion,
+    client_accepted_vanilla_core: bool,
+) -> Result<(), PacketHandlerError> {
+    let registry_provider = PrecomputedRegistries::new(protocol_version);
 
     // Send tags
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_21_6) {
-        // Since 1.21.6, the Dialog tags should be sent to have server links working
-        // Since 1.21.11, the Timeline tags should be sent to get the time of day working
-        // All tags are sent in a single packet
-        // TODO: `wolf_variant` tags should probably be sent too?
+        // Since 1.21.6, the Dialog tags should be sent to have server links working.
+        // Since 1.21.11, the Timeline tags should be sent to get the time of day working.
+        // All tags are sent in a single packet.
         let tagged_registries = registry_provider
             .get_tagged_registries()?
             .iter()
@@ -101,41 +131,76 @@ fn send_configuration_packets(
         batch.queue(|| PacketRegistry::UpdateTags(packet));
     }
 
-    // Send Registry Data
-    if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_5) {
-        // Since 1.20.5, each registry is sent in its own packet
-        batch.chain_iter(
-            registry_provider
-                .get_registry_data_v1_20_5()?
-                .into_iter()
-                .map(|(registry_id, registry_entries)| {
-                    let packet = RegistryDataPacket::registry(
-                        registry_id,
-                        registry_entries
-                            .iter()
-                            .map(|entry| {
-                                RegistryEntry::new(entry.entry_id.clone(), entry.nbt_bytes.clone())
-                            })
-                            .collect(),
-                    );
-                    PacketRegistry::RegistryData(packet)
-                }),
-        );
-    } else if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_2) {
-        // Since 1.19, all registries are sent as a single NBT tag
-        // Since 1.20.2, all registries are sent in their own packet during the configuration state, still as a single NBT tag
-        let registry_codec = registry_provider.get_registry_codec_v1_16()?;
-        let packet = RegistryDataPacket::codec(registry_codec);
-        batch.queue(|| PacketRegistry::RegistryData(packet));
-    } else {
-        // Registries are sent in the Join Game packet for versions prior to 1.20.2 since configuration state does not exist
-        unreachable!();
+    // Send Registry Data — only if the client did not accept the vanilla pack.
+    if !client_accepted_vanilla_core {
+        if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_5) {
+            // Since 1.20.5, each registry is sent in its own packet.
+            batch.chain_iter(
+                registry_provider
+                    .get_registry_data_v1_20_5()?
+                    .into_iter()
+                    .map(|(registry_id, registry_entries)| {
+                        let packet = RegistryDataPacket::registry(
+                            registry_id,
+                            registry_entries
+                                .iter()
+                                .map(|entry| {
+                                    RegistryEntry::new(
+                                        entry.entry_id.clone(),
+                                        entry.nbt_bytes.clone(),
+                                    )
+                                })
+                                .collect(),
+                        );
+                        PacketRegistry::RegistryData(packet)
+                    }),
+            );
+        } else if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_2) {
+            // Since 1.20.2 (no per-registry packets yet) the codec is sent as a
+            // single NBT compound.
+            let registry_codec = registry_provider.get_registry_codec_v1_16()?;
+            let packet = RegistryDataPacket::codec(registry_codec);
+            batch.queue(|| PacketRegistry::RegistryData(packet));
+        } else {
+            // Registries are sent in the Join Game packet for versions prior to
+            // 1.20.2 since configuration state does not exist.
+            unreachable!();
+        }
     }
 
     // Send Finished Configuration
     let packet = FinishConfigurationPacket {};
     batch.queue(|| PacketRegistry::FinishConfiguration(packet));
     Ok(())
+}
+
+impl PacketHandler for ServerBoundKnownPacksPacket {
+    fn handle(
+        &self,
+        client_state: &mut ClientState,
+        _server_state: &ServerState,
+    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+        let mut batch = Batch::new();
+        let protocol_version = client_state.protocol_version();
+
+        // The client replied with the list of known packs it accepts. If the
+        // list contains the vanilla `minecraft:core` pack at the version we
+        // proposed, the client has bundled vanilla registry data locally and
+        // we can skip sending registry data — matching Mojang vanilla / Paper.
+        let expected_version = known_pack_version(protocol_version);
+        let client_accepted_vanilla_core = self.known_packs.inner().iter().any(|pack| {
+            pack.namespace == "minecraft"
+                && pack.id == "core"
+                && pack.version == expected_version
+        });
+
+        send_post_known_packs_configuration_packets(
+            &mut batch,
+            protocol_version,
+            client_accepted_vanilla_core,
+        )?;
+        Ok(batch)
+    }
 }
 
 #[cfg(test)]
@@ -218,7 +283,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_configuration_packets_v1_20_5() {
+    async fn test_configuration_packets_v1_20_5_initial_sends_only_brand_and_known_packs() {
         // Given
         let mut batch = Batch::new();
 
@@ -226,7 +291,9 @@ mod tests {
         send_configuration_packets(&mut batch, ProtocolVersion::V1_20_5).unwrap();
         let mut batch = batch.into_stream();
 
-        // Then
+        // Then: the initial burst only sends brand + KnownPacks. The rest of
+        // the configuration (registries + FinishConfiguration) is sent only
+        // after the client's `select_known_packs` response.
         assert!(matches!(
             batch.next().await.unwrap(),
             PacketRegistry::ConfigurationClientBoundPluginMessage(_)
@@ -235,12 +302,52 @@ mod tests {
             batch.next().await.unwrap(),
             PacketRegistry::ClientBoundKnownPacks(_)
         ));
+        assert!(batch.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_post_known_packs_when_vanilla_rejected_sends_registries() {
+        // Given: client did NOT accept the vanilla pack.
+        let mut batch = Batch::new();
+
+        // When
+        send_post_known_packs_configuration_packets(
+            &mut batch,
+            ProtocolVersion::V1_20_5,
+            false,
+        )
+        .unwrap();
+        let mut batch = batch.into_stream();
+
+        // Then: registries are sent, followed by FinishConfiguration.
         for _ in 0..4 {
             assert!(matches!(
                 batch.next().await.unwrap(),
                 PacketRegistry::RegistryData(_)
             ));
         }
+        assert!(matches!(
+            batch.next().await.unwrap(),
+            PacketRegistry::FinishConfiguration(_)
+        ));
+        assert!(batch.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_post_known_packs_when_vanilla_accepted_skips_registries() {
+        // Given: client accepted the vanilla pack — server skips registry data.
+        let mut batch = Batch::new();
+
+        // When
+        send_post_known_packs_configuration_packets(
+            &mut batch,
+            ProtocolVersion::V1_20_5,
+            true,
+        )
+        .unwrap();
+        let mut batch = batch.into_stream();
+
+        // Then: only FinishConfiguration is sent (no registries).
         assert!(matches!(
             batch.next().await.unwrap(),
             PacketRegistry::FinishConfiguration(_)

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -92,7 +92,7 @@ fn send_configuration_packets(
     Ok(())
 }
 
-/// Sends the configuration packets that follow the optional KnownPacks handshake:
+/// Sends the configuration packets that follow the optional `KnownPacks` handshake:
 /// tags (`>= 1.21.6`), registry data (unless the client accepted vanilla), and
 /// `FinishConfiguration`.
 ///

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -28,6 +28,11 @@ impl PacketHandler for LoginAcknowledgedPacket {
         let protocol_version = client_state.protocol_version();
         if protocol_version.supports_configuration_state() {
             client_state.set_state(State::Configuration);
+            // Start the keep-alive ticker now: while the client is held in
+            // CONFIGURATION (e.g. by a proxy gating an auth flow) the server
+            // would otherwise stay silent on the backend connection, and
+            // Velocity's read-timeout (default 30s) would tear it down.
+            client_state.set_keep_alive_should_enable();
             send_configuration_packets(&mut batch, protocol_version)?;
             Ok(batch)
         } else {
@@ -237,6 +242,10 @@ mod tests {
 
         // Then
         assert_eq!(client_state.state(), State::Configuration);
+        assert!(
+            client_state.should_enable_keep_alive(),
+            "keep-alive must be requested as soon as CONFIGURATION starts",
+        );
         assert!(batch.next().await.is_some());
     }
 

--- a/pico_limbo/src/server/client_data.rs
+++ b/pico_limbo/src/server/client_data.rs
@@ -74,7 +74,9 @@ impl ClientData {
                 let period = Duration::from_secs(2);
                 self.interval().await.set_interval_at(start, period).await;
             } else {
-                let period = Duration::from_secs(15);
+                // 10 s gives a 3x safety margin under Velocity's default 30 s
+                // read-timeout, and matches the period used in CONFIGURATION state.
+                let period = Duration::from_secs(10);
                 self.interval().await.set_interval(period).await;
             }
             self.client().await.set_keep_alive_enabled();

--- a/pico_limbo/src/server/network.rs
+++ b/pico_limbo/src/server/network.rs
@@ -284,11 +284,18 @@ async fn send_keep_alive(client_data: &ClientData) -> Result<(), PacketProcessin
         (client.protocol_version(), client.state())
     };
 
-    if state == State::Play {
-        let packet = PacketRegistry::ClientBoundKeepAlive(ClientBoundKeepAlivePacket::random()?);
-        let raw_packet = packet.encode_packet(protocol_version)?;
-        client_data.write_packet(raw_packet).await?;
-    }
+    let packet = match state {
+        State::Configuration => PacketRegistry::ConfigurationClientBoundKeepAlive(
+            ClientBoundKeepAlivePacket::random()?,
+        ),
+        State::Play => {
+            PacketRegistry::ClientBoundKeepAlive(ClientBoundKeepAlivePacket::random()?)
+        }
+        _ => return Ok(()),
+    };
+
+    let raw_packet = packet.encode_packet(protocol_version)?;
+    client_data.write_packet(raw_packet).await?;
 
     Ok(())
 }

--- a/pico_limbo/src/server/packet_registry.rs
+++ b/pico_limbo/src/server/packet_registry.rs
@@ -5,6 +5,7 @@ use crate::server_state::ServerState;
 use macros::PacketReport;
 use minecraft_packets::configuration::acknowledge_finish_configuration_packet::AcknowledgeConfigurationPacket;
 use minecraft_packets::configuration::client_bound_known_packs_packet::ClientBoundKnownPacksPacket;
+use minecraft_packets::configuration::server_bound_known_packs_packet::ServerBoundKnownPacksPacket;
 use minecraft_packets::configuration::configuration_client_bound_plugin_message_packet::ConfigurationClientBoundPluginMessagePacket;
 use minecraft_packets::configuration::finish_configuration_packet::FinishConfigurationPacket;
 use minecraft_packets::configuration::registry_data_packet::RegistryDataPacket;
@@ -153,6 +154,13 @@ pub enum PacketRegistry {
         name = "minecraft:finish_configuration"
     )]
     AcknowledgeConfiguration(AcknowledgeConfigurationPacket),
+
+    #[protocol_id(
+        state = "configuration",
+        bound = "serverbound",
+        name = "minecraft:select_known_packs"
+    )]
+    ServerBoundSelectKnownPacks(ServerBoundKnownPacksPacket),
 
     #[protocol_id(
         state = "configuration",
@@ -367,6 +375,7 @@ impl PacketHandler for PacketRegistry {
             Self::CustomQueryAnswer(packet) => packet.handle(client_state, server_state),
             Self::LoginAcknowledged(packet) => packet.handle(client_state, server_state),
             Self::AcknowledgeConfiguration(packet) => packet.handle(client_state, server_state),
+            Self::ServerBoundSelectKnownPacks(packet) => packet.handle(client_state, server_state),
             Self::SetPlayerPositionAndRotation(packet) => packet.handle(client_state, server_state),
             Self::SetPlayerPosition(packet) => packet.handle(client_state, server_state),
             Self::ChatCommand(packet) => packet.handle(client_state, server_state),

--- a/pico_limbo/src/server/packet_registry.rs
+++ b/pico_limbo/src/server/packet_registry.rs
@@ -193,6 +193,13 @@ pub enum PacketRegistry {
     #[protocol_id(
         state = "configuration",
         bound = "clientbound",
+        name = "minecraft:keep_alive"
+    )]
+    ConfigurationClientBoundKeepAlive(ClientBoundKeepAlivePacket),
+
+    #[protocol_id(
+        state = "configuration",
+        bound = "clientbound",
         name = "minecraft:finish_configuration"
     )]
     FinishConfiguration(FinishConfigurationPacket),


### PR DESCRIPTION
# Fix Velocity + PacketEvents interop issues during configuration phase

## Context

We run PicoLimbo as a backend behind a Velocity proxy with PacketEvents 2.12.1. The proxy intentionally holds connecting players in the `CONFIGURATION` state for an extended period (typically more than 30 seconds) to run a custom registration / authentication dialog flow before transitioning the player to the actual gameplay server.

In this setup we hit a cluster of bugs that prevent PicoLimbo from working as a Velocity backend for modern Minecraft clients (1.21.11+ / protocol 26.1.x). This PR fixes all of them.

The root causes are independent but they interact:
- PacketEvents fails to parse the `minecraft:timeline` registry that PicoLimbo emits.
- PicoLimbo doesn't implement the `select_known_packs` handshake, so it sends every registry to every client.
- PicoLimbo sends a `minecraft:core` pack version string that doesn't match what 26.1.x clients have locally.
- PicoLimbo never sends `keep_alive` while the client is in `CONFIGURATION`, so Velocity's backend `read-timeout` (30 s by default) tears down the connection during the dialog flow.

---

## Bug 1 — `IllegalStateException` from PacketEvents on `minecraft:timeline`

**Symptom (Velocity logs):**

```
java.lang.IllegalStateException: Error while reading registry minecraft:timeline
```

Reproduces on every connection from a 26.1.x client passing through Velocity + PacketEvents 2.12.x.

**Root cause:**

PicoLimbo's `json_to_nbt` converter downcasts integers to the smallest-fitting NBT type (e.g. `0` → `Byte`, `1000` → `Short`, `24000` → `Short`) and downcasts floats to `Double` when precision can't round-trip to `Float`. Mojang's vanilla server emits the canonical NBT types: `Int` (or `Long` on overflow) for integers, `Float` (32-bit) for floats, always.

The MC 26.1 `minecraft:timeline` registry codec on the client (and the corresponding decoder in PacketEvents 2.12.x) expects strictly canonical tags. When a `Short(24000)` arrives where the codec expects `Int(24000)`, the decoder throws. Cross-reference: [retrooper/packetevents#1482](https://github.com/retrooper/packetevents/issues/1482).

**Fix:**

- New `NbtOptions::numeric_widening` flag in `pico_nbt` and a new `json_to_nbt_with_options(json, options)` entry point.
- When `numeric_widening` is enabled: integer JSON numbers always become `Value::Int` (or `Long` on overflow) — never downcast Byte/Short. Floats always become `Value::Float` (32-bit), even at the cost of f64→f32 precision. JSON booleans remain `Value::Byte(0/1)` (vanilla behavior). Integer arrays become `IntArray` / `LongArray`, never `ByteArray`.
- `pico_registries` is the only call site that loads registry JSON; it now passes `numeric_widening(true)`.
- Pinning regression test against the real `V26_1` `timeline/day` data report.

Default behavior of `json_to_nbt` (without the flag) is unchanged — any other use of the converter is unaffected.

---

## Bug 2 — Wrong `minecraft:core` pack version in `ClientBoundKnownPacksPacket`

**Symptom:**

A 26.1.x vanilla client never accepts the pack PicoLimbo offers. The client's `select_known_packs` response is an empty list.

**Root cause:**

`ClientBoundKnownPacksPacket::new(protocol_version.humanize())` — `humanize()` returns the protocol's minor name, which for `V26_1` is `"26.1"`. The client compares the pack version string strictly: a client running `26.1.2` has a locally-stored `minecraft:core@26.1.2` pack, not `minecraft:core@26.1`, so the offer is rejected and the client tells us it has no packs in common.

**Fix:**

New `known_pack_version(version)` helper that maps protocol versions whose Mojang release tag differs from `humanize()` to the right literal. Today only `V26_1 → "26.1.2"`; future protocols whose release tag matches `humanize()` fall through and don't need an arm.

Note: this only optimizes for 26.1.2 clients. Clients on 26.1.0 / 26.1.1 (same protocol number, different point release) will reject the offer and the server falls back to sending full registry data — which is correct, and the fallback path is now safe thanks to Bug 1's fix.

---

## Bug 3 — `select_known_packs` handshake not implemented

**Symptom:**

On `LoginAcknowledged`, PicoLimbo dumps the entire configuration burst (brand + `select_known_packs` offer + tags + every registry + `FinishConfiguration`) in one batch, regardless of how the client responds. Even when the client accepts the vanilla pack we offer, we still ship every registry — wasted bandwidth, and on Velocity + PacketEvents this is precisely the path that triggers Bug 1.

**Root cause:**

There is no `PacketIn` decoder for `select_known_packs`, no `ServerBoundSelectKnownPacks` variant in `PacketRegistry`, and no handler. The server-bound side of the handshake is dropped on the floor.

**Fix:**

- New `ServerBoundKnownPacksPacket` (in `minecraft_packets::configuration`) deriving `PacketIn`.
- New `ServerBoundSelectKnownPacks` variant in `PacketRegistry`, registered as `state = "configuration"`, `bound = "serverbound"`, `name = "minecraft:select_known_packs"`.
- `KnownPack` struct fields made `pub` so the server-bound handler can compare them.
- `send_configuration_packets` is split into two functions:
  - `send_configuration_packets`: for protocols `>= 1.20.5`, sends only brand + `select_known_packs` and stops. For pre-1.20.5 (no handshake), still emits the full burst as before.
  - `send_post_known_packs_configuration_packets`: sends tags + registry data (unless skipped) + `FinishConfiguration`. Called either directly (pre-1.20.5) or from the new handler (post-1.20.5).
- New `impl PacketHandler for ServerBoundKnownPacksPacket`: when the client's response contains `minecraft:core@<expected_version>`, registry data is skipped — matching Mojang vanilla / Paper behavior.

Pre-1.20.5 protocols are unaffected.

---

## Bug 4 — No `keep_alive` in CONFIGURATION state → Velocity `read-timeout`

**Symptom (Velocity logs):**

```
[connected player] read timed out
```

…fires after 30 seconds whenever the proxy holds the player in CONFIGURATION longer than that — which is exactly what our register/auth dialog does.

**Root cause:**

1. `PacketRegistry` only declares `ClientBoundKeepAlive` in `state = "play"`. The CONFIGURATION variant of the packet doesn't exist on the server side.
2. The keep-alive ticker (`ControllableInterval`) is only armed when `send_play_packets` runs, i.e. at the *end* of `AcknowledgeConfiguration`. While the client is held in CONFIGURATION, the ticker is idle and the backend connection sits silent on the network.
3. Even if the ticker were armed, `send_keep_alive` early-returns unless the client is in `State::Play`.

Velocity's default backend `read-timeout` is 30 seconds. Any CONFIGURATION hold longer than that → silent backend → connection torn down.

**Fix:**

- New `ConfigurationClientBoundKeepAlive` variant in `PacketRegistry`, reusing the existing `ClientBoundKeepAlivePacket` struct (the wire format is identical; only the per-state protocol ID differs and the `PacketReport` macro picks the right one per version).
- `send_keep_alive` now dispatches on `state`: emits `ConfigurationClientBoundKeepAlive` in `State::Configuration`, `ClientBoundKeepAlive` in `State::Play`, no-op elsewhere.
- The ticker is armed in the `LoginAcknowledged` handler (i.e. as soon as the client enters CONFIGURATION), not delayed until PLAY.
- Keep-alive period lowered from 15 s to 10 s — gives a 3× safety margin under Velocity's default 30 s `read-timeout` instead of a 2× margin.

---

## Why these are in one PR

Bug 1 by itself doesn't fix the Velocity backend scenario: even with canonical NBT, the client still gets timed out at 30 s if the proxy holds it in CONFIGURATION (Bug 4). Bugs 2 and 3 don't fix the crash from Bug 1 — they just avoid the code path that triggers it for vanilla clients. The four are entangled enough that they should land together.

Concrete coverage:
- Vanilla 1.21.11+ client connecting directly to PicoLimbo → needs Bug 1.
- Vanilla 1.21.11+ client connecting via Velocity + PacketEvents → needs Bug 1, or Bugs 2 + 3 (handshake skips the path).
- Modded / non-vanilla client (or one that rejects the pack offer) → only Bug 1 fixes it.
- Any client held in CONFIGURATION by a proxy for >30 s → needs Bug 4.

---

## Tests

- `pico_nbt`: 32 unit tests, including 14 new ones covering scalar and array widening for `numeric_widening`. Default code path is preserved.
- `pico_registries`: new integration test `registry_widening.rs` loads the real `V26_1` `timeline/day.json` from the data report and asserts canonical Int / Float at multiple paths (`period_ticks`, `time_markers.wake_up_from_sleep`, `time_markers.day.ticks`, `show_in_commands`, `moon_angle.ease.cubic_bezier[0]`).
- `pico_limbo`: refactored configuration tests into three (initial burst, vanilla-rejected post-handshake, vanilla-accepted post-handshake) and tightened the `LoginAcknowledged` test to assert the keep-alive ticker is armed.
- `cargo test --workspace`: all green.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.

---

## Compatibility

- No breaking changes to public API.
- `pico_nbt::json_to_nbt` keeps its previous signature and behavior; the new functionality is opt-in via `json_to_nbt_with_options(json, options)`.
- Pre-1.20.5 protocols are not affected by the handshake change — the full configuration burst is still sent in one go.
- Pre-1.21.x clients are not affected by the timeline registry change (timeline didn't exist).

---

## End-to-end verification

Built statically against `x86_64-unknown-linux-musl` and tested against the live setup: Velocity 3.5.x + PacketEvents 2.12.x + a 1.21.11+ client + a configuration dialog holding the player ~60 seconds.

Before this PR:
- `IllegalStateException: Error while reading registry minecraft:timeline` on every connection.
- After locally patching the parse crash, `[connected player] read timed out` at the 30 s mark.

After this PR:
- No parse crashes.
- No read timeouts.
- For 26.1.2 clients, the handshake correctly skips registry data; for older 26.1.x clients, the full registry path is taken and works.

---

## Commits

14 commits, grouped by bug:

**Bug 1 — NBT canonical types (5 commits):**
- `feat(nbt): add NbtOptions::numeric_widening flag`
- `feat(nbt): respect numeric_widening in json_to_nbt`
- `feat(nbt): re-export json_to_nbt_with_options`
- `fix(registries): emit canonical Int/Long NBT tags when loading registry JSON`
- `test(registries): assert timeline registry emits canonical Int+Float NBT tags`

**Bug 2 — pack version (1 commit):**
- `fix(login): send correct minecraft:core pack version per protocol`

**Bug 3 — KnownPacks handshake (4 commits):**
- `feat(packets): add ServerBoundKnownPacksPacket`
- `feat(packets): make KnownPack fields public`
- `feat(login): split configuration burst around the KnownPacks handshake`
- `style(login): backtick KnownPacks in doc comment for clippy`

**Bug 4 — keep-alive in CONFIG (4 commits):**
- `feat(packet-registry): add ConfigurationClientBoundKeepAlive variant`
- `refactor(keep-alive): lower interval from 15s to 10s`
- `feat(keep-alive): emit ConfigurationClientBoundKeepAlive in CONFIG state`
- `feat(keep-alive): start ticker when entering CONFIGURATION state`
