### PR TITLE
fix(registries): emit canonical Int/Float/Byte NBT tags for registry entries

### DIFF
--- a/pico_libraries/pico_nbt/src/json.rs
+++ b/pico_libraries/pico_nbt/src/json.rs
@@ -1,19 +1,51 @@
-use crate::{Error, Result, Value};
+use crate::{Error, NbtOptions, Result, Value};
 use serde_json::Value as JsonValue;
 
-/// Converts a JSON value to an NBT value.
-///
-/// # Errors
-/// Returns an error if:
-/// * The JSON contains a `null` value, which is not supported in NBT.
-/// * A number is invalid or cannot be represented in NBT types.
-/// * Array elements cannot be converted to NBT values.
-fn convert_array(arr: Vec<JsonValue>) -> Result<Value> {
+fn convert_number(n: &serde_json::Number, options: NbtOptions) -> Result<Value> {
+    if let Some(i) = n.as_i64() {
+        if options.is_numeric_widening() {
+            return i32::try_from(i)
+                .map_or_else(|_| Ok(Value::Long(i)), |int| Ok(Value::Int(int)));
+        }
+        return i8::try_from(i).map_or_else(
+            |_| {
+                i16::try_from(i).map_or_else(
+                    |_| {
+                        i32::try_from(i)
+                            .map_or_else(|_| Ok(Value::Long(i)), |int| Ok(Value::Int(int)))
+                    },
+                    |s| Ok(Value::Short(s)),
+                )
+            },
+            |s| Ok(Value::Byte(s)),
+        );
+    }
+
+    let f = n
+        .as_f64()
+        .ok_or_else(|| Error::Message("Invalid JSON number".into()))?;
+
+    #[allow(clippy::cast_possible_truncation)]
+    let f32_val = f as f32;
+
+    if options.is_numeric_widening() {
+        return Ok(Value::Float(f32_val));
+    }
+
+    if (f64::from(f32_val) - f).abs() < f64::EPSILON {
+        Ok(Value::Float(f32_val))
+    } else {
+        Ok(Value::Double(f))
+    }
+}
+
+fn convert_array(arr: Vec<JsonValue>, options: NbtOptions) -> Result<Value> {
     if arr.is_empty() {
         return Ok(Value::List(Vec::new()));
     }
 
-    let mut is_byte = true;
+    let widening = options.is_numeric_widening();
+    let mut is_byte = !widening;
     let mut is_int = true;
     let mut is_long = true;
 
@@ -85,12 +117,12 @@ fn convert_array(arr: Vec<JsonValue>) -> Result<Value> {
 
     let mut list = Vec::with_capacity(arr.len());
     for elem in arr {
-        list.push(json_to_nbt(elem)?);
+        list.push(json_to_nbt_with_options(elem, options)?);
     }
     Ok(Value::List(list))
 }
 
-/// Converts a JSON value to an NBT value.
+/// Converts a JSON value to an NBT value using the default options.
 ///
 /// # Errors
 /// Returns an error if:
@@ -98,46 +130,32 @@ fn convert_array(arr: Vec<JsonValue>) -> Result<Value> {
 /// * A number is invalid or cannot be represented in NBT types.
 /// * Array elements cannot be converted to NBT values.
 pub fn json_to_nbt(json: JsonValue) -> Result<Value> {
+    json_to_nbt_with_options(json, NbtOptions::new())
+}
+
+/// Converts a JSON value to an NBT value using the provided options.
+///
+/// With `NbtOptions::numeric_widening` enabled, integers are emitted as `Int`
+/// (or `Long` on `i32` overflow), floats as `Float`, and homogeneous integer
+/// arrays as `IntArray` / `LongArray` — matching what Mojang's `Codec` API
+/// produces against `NbtOps.INSTANCE` for canonical registry encoding.
+///
+/// # Errors
+/// Returns an error if:
+/// * The JSON contains a `null` value, which is not supported in NBT.
+/// * A number is invalid or cannot be represented in NBT types.
+/// * Array elements cannot be converted to NBT values.
+pub fn json_to_nbt_with_options(json: JsonValue, options: NbtOptions) -> Result<Value> {
     match json {
         JsonValue::Null => Err(Error::Message("JSON null is not supported in NBT".into())),
         JsonValue::Bool(b) => Ok(Value::Byte(i8::from(b))),
-        JsonValue::Number(n) => n.as_i64().map_or_else(
-            || {
-                n.as_f64().map_or_else(
-                    || Err(Error::Message("Invalid JSON number".into())),
-                    |f| {
-                        #[allow(clippy::cast_possible_truncation)]
-                        // I cannot find a better solution than casting the double down to float
-                        let f32_val = f as f32;
-                        if (f64::from(f32_val) - f).abs() < f64::EPSILON {
-                            Ok(Value::Float(f32_val))
-                        } else {
-                            Ok(Value::Double(f))
-                        }
-                    },
-                )
-            },
-            |i| {
-                i8::try_from(i).map_or_else(
-                    |_| {
-                        i16::try_from(i).map_or_else(
-                            |_| {
-                                i32::try_from(i)
-                                    .map_or_else(|_| Ok(Value::Long(i)), |int| Ok(Value::Int(int)))
-                            },
-                            |s| Ok(Value::Short(s)),
-                        )
-                    },
-                    |s| Ok(Value::Byte(s)),
-                )
-            },
-        ),
+        JsonValue::Number(n) => convert_number(&n, options),
         JsonValue::String(s) => Ok(Value::String(s)),
-        JsonValue::Array(arr) => convert_array(arr),
+        JsonValue::Array(arr) => convert_array(arr, options),
         JsonValue::Object(obj) => {
             let mut map = indexmap::IndexMap::new();
             for (k, v) in obj {
-                map.insert(k, json_to_nbt(v)?);
+                map.insert(k, json_to_nbt_with_options(v, options)?);
             }
             Ok(Value::Compound(map))
         }
@@ -148,6 +166,10 @@ pub fn json_to_nbt(json: JsonValue) -> Result<Value> {
 mod tests {
     use crate::*;
     use serde_json::json;
+
+    fn widening() -> NbtOptions {
+        NbtOptions::new().numeric_widening(true)
+    }
 
     #[test]
     fn bool_true() {
@@ -313,5 +335,145 @@ mod tests {
     fn test_json_null_error() {
         let res = json_to_nbt(json!(null));
         assert!(res.is_err());
+    }
+
+    // --- numeric_widening tests ---
+
+    #[test]
+    fn widening_zero_is_int() {
+        assert_eq!(
+            json_to_nbt_with_options(json!(0), widening()).unwrap(),
+            Value::Int(0)
+        );
+    }
+
+    #[test]
+    fn widening_short_range_is_int() {
+        assert_eq!(
+            json_to_nbt_with_options(json!(128), widening()).unwrap(),
+            Value::Int(128)
+        );
+    }
+
+    #[test]
+    fn widening_i32_max_is_int() {
+        assert_eq!(
+            json_to_nbt_with_options(json!(i32::MAX), widening()).unwrap(),
+            Value::Int(i32::MAX)
+        );
+    }
+
+    #[test]
+    fn widening_overflow_is_long() {
+        assert_eq!(
+            json_to_nbt_with_options(json!(2_147_483_649_u64), widening()).unwrap(),
+            Value::Long(2_147_483_649)
+        );
+    }
+
+    #[test]
+    fn widening_negative_is_int() {
+        assert_eq!(
+            json_to_nbt_with_options(json!(-42), widening()).unwrap(),
+            Value::Int(-42)
+        );
+    }
+
+    #[test]
+    fn widening_bool_stays_byte() {
+        assert_eq!(
+            json_to_nbt_with_options(json!(true), widening()).unwrap(),
+            Value::Byte(1)
+        );
+        assert_eq!(
+            json_to_nbt_with_options(json!(false), widening()).unwrap(),
+            Value::Byte(0)
+        );
+    }
+
+    #[test]
+    fn widening_float_exact_is_float() {
+        assert_eq!(
+            json_to_nbt_with_options(json!(std::f32::consts::PI), widening()).unwrap(),
+            Value::Float(std::f32::consts::PI)
+        );
+    }
+
+    #[test]
+    fn widening_float_lossy_is_float() {
+        // 0.362 is not exactly representable in f32, but Mojang's Codec.FLOAT
+        // still emits a FloatTag rather than promoting to DoubleTag.
+        let Value::Float(f) = json_to_nbt_with_options(json!(0.362), widening()).unwrap() else {
+            panic!("Expected Float");
+        };
+        assert!((f - 0.362_f32).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn widening_nested_compound() {
+        let json_data = json!({
+            "period_ticks": 24000,
+            "show_in_commands": true,
+            "ratio": 0.5
+        });
+        let nbt = json_to_nbt_with_options(json_data, widening()).unwrap();
+        let Value::Compound(map) = nbt else {
+            panic!("Expected Compound");
+        };
+        assert_eq!(map.get("period_ticks"), Some(&Value::Int(24000)));
+        assert_eq!(map.get("show_in_commands"), Some(&Value::Byte(1)));
+        assert_eq!(map.get("ratio"), Some(&Value::Float(0.5_f32)));
+    }
+
+    #[test]
+    fn default_options_unchanged_byte_path() {
+        // Default behavior (no widening) must still downcast small ints to Byte.
+        assert_eq!(
+            json_to_nbt_with_options(json!(0), NbtOptions::new()).unwrap(),
+            Value::Byte(0)
+        );
+        assert_eq!(
+            json_to_nbt_with_options(json!(128), NbtOptions::new()).unwrap(),
+            Value::Short(128)
+        );
+    }
+
+    #[test]
+    fn widening_byte_range_array_is_int_array() {
+        let nbt = json_to_nbt_with_options(json!([1, 2, 3]), widening()).unwrap();
+        let Value::IntArray(arr) = nbt else {
+            panic!("Expected IntArray, got {nbt:?}");
+        };
+        assert_eq!(arr, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn widening_short_range_array_is_int_array() {
+        let nbt = json_to_nbt_with_options(json!([1, 200, 30_000]), widening()).unwrap();
+        let Value::IntArray(arr) = nbt else {
+            panic!("Expected IntArray, got {nbt:?}");
+        };
+        assert_eq!(arr, vec![1, 200, 30_000]);
+    }
+
+    #[test]
+    fn widening_overflow_array_is_long_array() {
+        let nbt = json_to_nbt_with_options(
+            json!([1_i64, 10_000_000_000_i64]),
+            widening(),
+        )
+        .unwrap();
+        let Value::LongArray(arr) = nbt else {
+            panic!("Expected LongArray, got {nbt:?}");
+        };
+        assert_eq!(arr, vec![1, 10_000_000_000]);
+    }
+
+    #[test]
+    fn default_byte_array_still_byte() {
+        // Default behavior (no widening) must still produce ByteArray for tiny ints.
+        let nbt =
+            json_to_nbt_with_options(json!([1, 2, 3]), NbtOptions::new()).unwrap();
+        assert!(matches!(nbt, Value::ByteArray(_)));
     }
 }

--- a/pico_libraries/pico_nbt/src/lib.rs
+++ b/pico_libraries/pico_nbt/src/lib.rs
@@ -12,7 +12,7 @@ pub use de::from_value;
 pub use error::{Error, Result};
 pub use indexmap::IndexMap;
 pub use io::{CompressionType, decode, encode};
-pub use json::json_to_nbt;
+pub use json::{json_to_nbt, json_to_nbt_with_options};
 pub use options::NbtOptions;
 pub use reader::{
     from_file, from_file_struct, from_path, from_path_struct, from_path_with_options, from_reader,

--- a/pico_libraries/pico_nbt/src/options.rs
+++ b/pico_libraries/pico_nbt/src/options.rs
@@ -6,6 +6,7 @@ pub struct NbtOptions {
 
 const NAMELESS_ROOT: u8 = 1 << 0;
 const DYNAMIC_LISTS: u8 = 1 << 1;
+const NUMERIC_WIDENING: u8 = 1 << 2;
 
 impl NbtOptions {
     /// Creates a new `NbtOptions` with default settings.
@@ -43,6 +44,32 @@ impl NbtOptions {
         self
     }
 
+    /// Sets whether to widen numeric JSON values to canonical Mojang NBT tags during
+    /// JSON-to-NBT conversion.
+    ///
+    /// When enabled:
+    /// * All JSON integers are emitted as `Int` (or `Long` when they overflow `i32`),
+    ///   never downcast to `Byte` or `Short`.
+    /// * All JSON floats that round-trip through `f32` are emitted as `Float`,
+    ///   matching what `Codec.FLOAT` produces against `NbtOps.INSTANCE`.
+    /// * Homogeneous integer arrays are emitted as `IntArray` / `LongArray`,
+    ///   never as `ByteArray`.
+    /// * JSON booleans remain `Byte(0/1)`, matching `NbtOps.createBoolean`.
+    ///
+    /// This mirrors the canonical encoding produced by Mojang's `Codec` API when
+    /// serializing registry classes via `NbtOps.INSTANCE`, and is required to match
+    /// the wire format that strict client codecs (e.g. `PacketEvents` 2.12.x) expect
+    /// for registry entries on 1.21.6+.
+    #[must_use]
+    pub const fn numeric_widening(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.flags |= NUMERIC_WIDENING;
+        } else {
+            self.flags &= !NUMERIC_WIDENING;
+        }
+        self
+    }
+
     /// Checks if nameless root is enabled.
     #[must_use]
     pub const fn is_nameless_root(&self) -> bool {
@@ -53,5 +80,50 @@ impl NbtOptions {
     #[must_use]
     pub const fn is_dynamic_lists(&self) -> bool {
         (self.flags & DYNAMIC_LISTS) != 0
+    }
+
+    /// Checks if numeric widening is enabled.
+    #[must_use]
+    pub const fn is_numeric_widening(&self) -> bool {
+        (self.flags & NUMERIC_WIDENING) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numeric_widening_default_false() {
+        assert!(!NbtOptions::new().is_numeric_widening());
+    }
+
+    #[test]
+    fn numeric_widening_can_be_enabled() {
+        assert!(NbtOptions::new().numeric_widening(true).is_numeric_widening());
+    }
+
+    #[test]
+    fn numeric_widening_can_be_disabled() {
+        let opts = NbtOptions::new()
+            .numeric_widening(true)
+            .numeric_widening(false);
+        assert!(!opts.is_numeric_widening());
+    }
+
+    #[test]
+    fn numeric_widening_does_not_collide_with_other_flags() {
+        let opts = NbtOptions::new()
+            .nameless_root(true)
+            .dynamic_lists(true)
+            .numeric_widening(true);
+        assert!(opts.is_nameless_root());
+        assert!(opts.is_dynamic_lists());
+        assert!(opts.is_numeric_widening());
+
+        let opts = opts.numeric_widening(false);
+        assert!(opts.is_nameless_root());
+        assert!(opts.is_dynamic_lists());
+        assert!(!opts.is_numeric_widening());
     }
 }

--- a/pico_libraries/pico_registries/src/data/registry.rs
+++ b/pico_libraries/pico_registries/src/data/registry.rs
@@ -106,7 +106,10 @@ impl Registry {
                 };
                 let json_data = serde_json::from_str(&json_str)?;
 
-                let nbt_value = pico_nbt::json_to_nbt(json_data)?;
+                let nbt_value = pico_nbt::json_to_nbt_with_options(
+                    json_data,
+                    pico_nbt::NbtOptions::new().numeric_widening(true),
+                )?;
 
                 let entry = RegistryEntry::new(value, nbt_value, registry_key, protocol_id);
                 protocol_id += 1;

--- a/pico_libraries/pico_registries/tests/registry_widening.rs
+++ b/pico_libraries/pico_registries/tests/registry_widening.rs
@@ -1,0 +1,144 @@
+//! Integration test that locks the canonical NBT types emitted when loading
+//! the real `V26_1/data/minecraft/timeline/day.json` data report.
+//!
+//! This test guards against regressions of the `numeric_widening` flag: every
+//! field below corresponds to a Mojang `Codec` declaration whose canonical NBT
+//! encoding via `NbtOps.INSTANCE` is `IntTag` / `FloatTag` / `ByteTag`,
+//! verified directly against the MC 26.1.2 server jar bytecode.
+
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::manual_assert,
+    clippy::indexing_slicing
+)]
+
+use pico_nbt::{IndexMap, Value};
+use pico_registries::{Identifier, Registry, RegistryKeys};
+use std::path::PathBuf;
+
+fn data_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("data")
+        .join("generated")
+        .join("V26_1")
+        .join("data")
+}
+
+fn load_timeline_day() -> Value {
+    let registry = Registry::load(&RegistryKeys::Timeline, &data_root())
+        .expect("timeline registry should load from V26_1 data");
+    let day_id = Identifier::vanilla_unchecked("day");
+    let entry = registry
+        .get(&day_id)
+        .expect("day entry should be present in timeline registry");
+    entry.get_raw_value().clone()
+}
+
+fn compound<'a>(value: &'a Value, msg: &str) -> &'a IndexMap<String, Value> {
+    let Value::Compound(map) = value else {
+        panic!("Expected compound at {msg}, got {value:?}");
+    };
+    map
+}
+
+fn list<'a>(value: &'a Value, msg: &str) -> &'a Vec<Value> {
+    let Value::List(items) = value else {
+        panic!("Expected list at {msg}, got {value:?}");
+    };
+    items
+}
+
+#[test]
+fn period_ticks_is_int() {
+    let day = load_timeline_day();
+    let root = compound(&day, "root");
+    assert_eq!(
+        root.get("period_ticks"),
+        Some(&Value::Int(24000)),
+        "period_ticks must be IntTag, not Short/Byte — Mojang's ExtraCodecs.POSITIVE_INT \
+         (a Codec<Integer>) calls NbtOps.createInt which always emits IntTag"
+    );
+}
+
+#[test]
+fn time_marker_scalar_is_int() {
+    let day = load_timeline_day();
+    let root = compound(&day, "root");
+    let markers = compound(
+        root.get("time_markers")
+            .expect("time_markers field must exist"),
+        "time_markers",
+    );
+    assert_eq!(
+        markers.get("minecraft:wake_up_from_sleep"),
+        Some(&Value::Int(0)),
+        "scalar time marker tick value must be IntTag, not ByteTag(0)"
+    );
+}
+
+#[test]
+fn time_marker_compound_ticks_is_int_and_bool_is_byte() {
+    let day = load_timeline_day();
+    let root = compound(&day, "root");
+    let markers = compound(
+        root.get("time_markers")
+            .expect("time_markers field must exist"),
+        "time_markers",
+    );
+    let day_marker = compound(
+        markers
+            .get("minecraft:day")
+            .expect("minecraft:day marker must exist"),
+        "minecraft:day",
+    );
+    assert_eq!(
+        day_marker.get("ticks"),
+        Some(&Value::Int(1000)),
+        "ticks field must be IntTag, not ShortTag(1000)"
+    );
+    assert_eq!(
+        day_marker.get("show_in_commands"),
+        Some(&Value::Byte(1)),
+        "boolean show_in_commands must remain ByteTag(1) — NbtOps.createBoolean \
+         emits ByteTag, never IntTag"
+    );
+}
+
+#[test]
+fn cubic_bezier_keyframe_is_float() {
+    let day = load_timeline_day();
+    let root = compound(&day, "root");
+    let tracks = compound(
+        root.get("tracks").expect("tracks field must exist"),
+        "tracks",
+    );
+    let moon_angle = compound(
+        tracks
+            .get("minecraft:visual/moon_angle")
+            .expect("moon_angle track must exist"),
+        "moon_angle",
+    );
+    let ease = compound(
+        moon_angle.get("ease").expect("ease field must exist"),
+        "ease",
+    );
+    let bezier = list(
+        ease.get("cubic_bezier")
+            .expect("cubic_bezier field must exist"),
+        "cubic_bezier",
+    );
+    assert_eq!(bezier.len(), 4, "cubic_bezier must have 4 control values");
+    let Value::Float(f) = bezier[0] else {
+        panic!(
+            "cubic_bezier[0] must be FloatTag — EasingType$CubicBezierControls is a Java record \
+             with four float fields encoded via Codec.FLOAT; got {:?}",
+            bezier[0]
+        );
+    };
+    if (f - 0.362_f32).abs() >= 1e-5 {
+        panic!("cubic_bezier[0] expected ~0.362f, got {f}");
+    }
+}


### PR DESCRIPTION
PacketEvents 2.12.x logs `IllegalStateException: Error while reading registry minecraft:timeline` on every connect from a 1.21.11+ client (retrooper/packetevents#1482).

### Root cause
`json_to_nbt` was picking the smallest int type that fits each value (`0` → Byte, `1000` → Short, `24000` → Short...) and routing lossy floats to Double to preserve precision. Vanilla doesn't do that. `NbtOps.createInt(int)` always returns `IntTag`, `createFloat(float)` always returns `FloatTag`, and `createBoolean(boolean)` stays `ByteTag`. The vanilla client is lenient w/ wider tags; PE's mirror codec isn't.

Checked the 26.1.2 server jar directly (mojmap is in the clear nowadays, so this is verifiable):
- `NbtOps.createInt(I)` -> `IntTag.valueOf(I)` no downcast
- `NbtOps.createFloat(F)` -> `FloatTag.valueOf(F)` never promoted to Double
- `Timeline.DIRECT_CODEC` ties `period_ticks` to `ExtraCodecs.POSITIVE_INT` (a `Codec<Integer>` over `Codec.INT`) -> emits `IntTag(24000)`, not `ShortTag(24000)`
- `EasingType$CubicBezierControls` is a record w/ four `float` fields -> `Codec.FLOAT` -> `FloatTag`

It's what Mojang's typed `Codec` API emits when serializing registry classes through `NbtOps.INSTANCE`.

### Fix
New opt-in `NbtOptions::numeric_widening` flag + a `json_to_nbt_with_options` entry point. With the flag on:
- ints stay `Int` (or `Long` on i32 overflow) - no Byte/Short downcast
- floats stay `Float`, even when the f64 doesn't round-trip exactly
- homogeneous int arrays become `IntArray` / `LongArray`, no `ByteArray`
- booleans stay `Byte`, same as `NbtOps.createBoolean`

`json_to_nbt`'s default behaviour is untouched. Only `pico_registries` opts in when loading the generated data reports, so nothing outside the registry loader moves.

### Test
An integration test at `pico_libraries/pico_registries/tests/registry_widening.rs` pins the expected types against the real `V26_1/timeline/day.json` data report (`period_ticks: Int(24000)`, marker `ticks: Int(1000)`, `show_in_commands: Byte(1)`, `cubic_bezier[0]: Float(~0.362)` etc), so a future regression on the canonical encoding hits CI.

### Scope
The non-canonical encoding affected every registry PicoLimbo emits, not just `minecraft:timeline`. Timeline just happens to be where PE's stricter codec trips first. Fixing at the converter level covers all registries in one go.

No version gating needed, the change is purely about how data reports get loaded into NBT.
