### PR TITLE
feat(login): handle select_known_packs and skip registries when accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The plugin doesn't shutdown when shutting down the proxy
-- Do not send registry data starting 1.21.5, this should fix issues with PacketEvents some users were having
+- PicoLimbo should wait for client known packs before sending registry data (starting 1.20.5)
+- Registry data can be omitted if it is known by the client (starting 1.21.5)
 
 ## [1.12.2+mc26.1.2] - 2026-04-12
 

--- a/crates/minecraft_packets/src/configuration/client_bound_known_packs_packet.rs
+++ b/crates/minecraft_packets/src/configuration/client_bound_known_packs_packet.rs
@@ -7,9 +7,13 @@ pub struct ClientBoundKnownPacksPacket {
 }
 
 impl ClientBoundKnownPacksPacket {
-    pub fn new(version: &str) -> Self {
+    pub fn new(versions: &[&str]) -> Self {
+        let known_packs = versions
+            .iter()
+            .map(|version| KnownPack::new(version))
+            .collect::<Vec<_>>();
         Self {
-            known_packs: LengthPaddedVec::new(vec![KnownPack::new(version)]),
+            known_packs: LengthPaddedVec::new(known_packs),
         }
     }
 }

--- a/crates/minecraft_packets/src/configuration/data/known_pack.rs
+++ b/crates/minecraft_packets/src/configuration/data/known_pack.rs
@@ -2,9 +2,9 @@ use minecraft_protocol::prelude::*;
 
 #[derive(PacketIn, PacketOut)]
 pub struct KnownPack {
-    namespace: String,
-    id: String,
-    version: String,
+    pub namespace: String,
+    pub id: String,
+    pub version: String,
 }
 
 impl KnownPack {

--- a/crates/minecraft_packets/src/configuration/data/known_pack.rs
+++ b/crates/minecraft_packets/src/configuration/data/known_pack.rs
@@ -2,9 +2,9 @@ use minecraft_protocol::prelude::*;
 
 #[derive(PacketIn, PacketOut)]
 pub struct KnownPack {
-    pub namespace: String,
-    pub id: String,
-    pub version: String,
+    namespace: String,
+    id: String,
+    version: String,
 }
 
 impl KnownPack {
@@ -14,5 +14,9 @@ impl KnownPack {
             id: "core".to_string(),
             version: version.to_string(),
         }
+    }
+
+    pub fn is_minecraft_core(&self) -> bool {
+        self.namespace == "minecraft" && self.id == "core"
     }
 }

--- a/crates/minecraft_packets/src/configuration/mod.rs
+++ b/crates/minecraft_packets/src/configuration/mod.rs
@@ -4,4 +4,5 @@ pub mod configuration_client_bound_plugin_message_packet;
 pub mod data;
 pub mod finish_configuration_packet;
 pub mod registry_data_packet;
+pub mod server_bound_known_packs_packet;
 pub mod update_tags_packet;

--- a/crates/minecraft_packets/src/configuration/server_bound_known_packs_packet.rs
+++ b/crates/minecraft_packets/src/configuration/server_bound_known_packs_packet.rs
@@ -1,0 +1,7 @@
+use crate::configuration::data::known_pack::KnownPack;
+use minecraft_protocol::prelude::*;
+
+#[derive(PacketIn)]
+pub struct ServerBoundKnownPacksPacket {
+    pub known_packs: LengthPaddedVec<KnownPack>,
+}

--- a/crates/minecraft_packets/src/configuration/server_bound_known_packs_packet.rs
+++ b/crates/minecraft_packets/src/configuration/server_bound_known_packs_packet.rs
@@ -3,5 +3,20 @@ use minecraft_protocol::prelude::*;
 
 #[derive(PacketIn)]
 pub struct ServerBoundKnownPacksPacket {
-    pub known_packs: LengthPaddedVec<KnownPack>,
+    known_packs: LengthPaddedVec<KnownPack>,
+}
+
+impl ServerBoundKnownPacksPacket {
+    pub fn new(known_packs: Vec<KnownPack>) -> Self {
+        Self {
+            known_packs: LengthPaddedVec::new(known_packs),
+        }
+    }
+
+    pub fn has_minecraft_core(&self) -> bool {
+        self.known_packs
+            .inner()
+            .iter()
+            .any(KnownPack::is_minecraft_core)
+    }
 }

--- a/crates/protocol_version/src/protocol_version.rs
+++ b/crates/protocol_version/src/protocol_version.rs
@@ -5,20 +5,27 @@ use std::cmp::PartialEq;
 #[repr(i32)]
 pub enum ProtocolVersion {
     #[default]
+    #[pvn(known_packs = ["26.1", "26.1.1", "26.1.2"])]
     V26_1 = 775,
-    #[pvn(packets = V1_21_9)]
+    #[pvn(packets = V1_21_9, known_packs = ["1.21.11"])]
     V1_21_11 = 774,
-    #[pvn(data = V1_21_6)]
+    #[pvn(data = V1_21_6, known_packs = ["1.21.9", "1.21.10"])]
     V1_21_9 = 773,
-    #[pvn(packets = V1_21_6, data = V1_21_6)]
+    #[pvn(packets = V1_21_6, data = V1_21_6, known_packs = ["1.21.7", "1.21.8"])]
     V1_21_7 = 772,
+    #[pvn(known_packs = ["1.21.6"])]
     V1_21_6 = 771,
+    #[pvn(known_packs = ["1.21.5"])]
     V1_21_5 = 770,
+    #[pvn(known_packs = ["1.21.4"])]
     V1_21_4 = 769,
     /// Docs: https://minecraft.wiki/w/Java_Edition_protocol/Packets?oldid=2780220
+    #[pvn(known_packs = ["1.21.2", "1.21.3"])]
     V1_21_2 = 768,
+    #[pvn(known_packs = ["1.21", "1.21.1"])]
     V1_21 = 767,
 
+    #[pvn(known_packs = ["1.20.5", "1.20.6"])]
     V1_20_5 = 766,
     #[pvn(data = V1_20_2)]
     V1_20_3 = 765,

--- a/crates/protocol_version_macro/src/expand.rs
+++ b/crates/protocol_version_macro/src/expand.rs
@@ -91,6 +91,12 @@ pub fn expand_protocol_version_derive(input: TokenStream) -> TokenStream {
         quote! { #enum_ident::#variant_ident => #enum_ident::#value }
     });
 
+    let known_packs_arms = parsed_variants.iter().map(|v| {
+        let variant_ident = v.ident;
+        let packs = &v.known_packs;
+        quote! { #enum_ident::#variant_ident => &[#(#packs),*] }
+    });
+
     let all_versions_arms = parsed_variants.iter().map(|v| {
         let variant_ident = v.ident;
         quote! { #enum_ident::#variant_ident }
@@ -162,6 +168,11 @@ pub fn expand_protocol_version_derive(input: TokenStream) -> TokenStream {
             /// Returns the protocol version this version gets its data from.
             pub fn data(&self) -> ProtocolVersion {
                 match self { #(#data_arms),* }
+            }
+
+            /// Returns the known packs for this protocol version.
+            pub fn known_packs(&self) -> &'static [&'static str] {
+                match self { #(#known_packs_arms),* }
             }
 
             /// Returns the latest real protocol version (ignores special values like `Any`).

--- a/crates/protocol_version_macro/src/parsed_variant.rs
+++ b/crates/protocol_version_macro/src/parsed_variant.rs
@@ -9,6 +9,7 @@ pub struct ParsedVariant<'a> {
     pub humanized_string: LitStr,
     pub packets: Ident,
     pub data: Ident,
+    pub known_packs: Vec<String>,
 }
 
 impl<'a> ParsedVariant<'a> {
@@ -26,6 +27,8 @@ impl<'a> ParsedVariant<'a> {
 
         let data = pvn_attribute.data.unwrap_or_else(|| variant.ident.clone());
 
+        let known_packs = pvn_attribute.known_packs;
+
         Ok(Self {
             ident: &variant.ident,
             discriminant_expr,
@@ -33,6 +36,7 @@ impl<'a> ParsedVariant<'a> {
             humanized_string,
             packets,
             data,
+            known_packs,
         })
     }
 
@@ -102,6 +106,7 @@ impl<'a> ParsedVariant<'a> {
             Ok(PvnAttribute {
                 packets: None,
                 data: None,
+                known_packs: vec![],
             })
         }
     }

--- a/crates/protocol_version_macro/src/pvn_attribute.rs
+++ b/crates/protocol_version_macro/src/pvn_attribute.rs
@@ -1,19 +1,25 @@
 use syn::parse::{Parse, ParseStream};
-use syn::{Error, Ident, Result, Token};
+use syn::{Error, Ident, LitStr, Result, Token};
 
-/// Parses the `#[pvn(reports = "...", data = "...")]` attribute.
+/// Parses the `#[pvn(packets = "...", data = "...", known_packs = [...])]` attribute.
 pub struct PvnAttribute {
     pub packets: Option<Ident>,
     pub data: Option<Ident>,
+    pub known_packs: Vec<String>,
 }
 
 impl Parse for PvnAttribute {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut packets: Option<Ident> = None;
         let mut data: Option<Ident> = None;
+        let mut known_packs: Vec<String> = Vec::new();
 
         if input.is_empty() {
-            return Ok(PvnAttribute { packets, data });
+            return Ok(PvnAttribute {
+                packets,
+                data,
+                known_packs,
+            });
         }
 
         let mut parse_kv = |input: ParseStream| -> Result<()> {
@@ -32,10 +38,23 @@ impl Parse for PvnAttribute {
                 }
                 let value: Ident = input.parse()?;
                 data = Some(value);
+            } else if ident == "known_packs" {
+                if !known_packs.is_empty() {
+                    return Err(Error::new(ident.span(), "duplicate `known_packs` field"));
+                }
+                let content;
+                syn::bracketed!(content in input);
+                while !content.is_empty() {
+                    let s: LitStr = content.parse()?;
+                    known_packs.push(s.value());
+                    if content.peek(Token![,]) {
+                        content.parse::<Token![,]>()?;
+                    }
+                }
             } else {
                 return Err(Error::new(
                     ident.span(),
-                    "expected either `packets` or `data`",
+                    "expected `packets`, `data`, or `known_packs`",
                 ));
             }
             Ok(())
@@ -47,6 +66,10 @@ impl Parse for PvnAttribute {
             parse_kv(input)?;
         }
 
-        Ok(PvnAttribute { packets, data })
+        Ok(PvnAttribute {
+            packets,
+            data,
+            known_packs,
+        })
     }
 }

--- a/data/generated/V1_20_5/reports/packets.json
+++ b/data/generated/V1_20_5/reports/packets.json
@@ -29,6 +29,9 @@
       },
       "minecraft:finish_configuration": {
         "protocol_id": 3
+      },
+      "minecraft:select_known_packs": {
+        "protocol_id": 7
       }
     }
   },

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -9,6 +9,7 @@ use minecraft_packets::configuration::configuration_client_bound_plugin_message_
 use minecraft_packets::configuration::data::registry_entry::RegistryEntry;
 use minecraft_packets::configuration::finish_configuration_packet::FinishConfigurationPacket;
 use minecraft_packets::configuration::registry_data_packet::RegistryDataPacket;
+use minecraft_packets::configuration::server_bound_known_packs_packet::ServerBoundKnownPacksPacket;
 use minecraft_packets::configuration::update_tags_packet::{
     RegistryTag, TaggedRegistry, UpdateTagsPacket,
 };
@@ -37,22 +38,57 @@ impl PacketHandler for LoginAcknowledgedPacket {
     }
 }
 
+impl PacketHandler for ServerBoundKnownPacksPacket {
+    fn handle(
+        &self,
+        client_state: &mut ClientState,
+        _server_state: &ServerState,
+    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+        let mut batch = Batch::new();
+        let protocol_version = client_state.protocol_version();
+        let expected_version = protocol_version.humanize();
+        let client_accepted_vanilla_core = self.known_packs.inner().iter().any(|pack| {
+            pack.namespace == "minecraft" && pack.id == "core" && pack.version == expected_version
+        });
+        send_post_known_packs_configuration_packets(
+            &mut batch,
+            protocol_version,
+            client_accepted_vanilla_core,
+        )?;
+        Ok(batch)
+    }
+}
+
 /// Only for >= 1.20.2
 fn send_configuration_packets(
     batch: &mut Batch<PacketRegistry>,
     protocol_version: ProtocolVersion,
 ) -> Result<(), PacketHandlerError> {
-    let registry_provider = PrecomputedRegistries::new(protocol_version);
-
     // Send Server Brand
     let packet = ConfigurationClientBoundPluginMessagePacket::brand(SERVER_BRAND);
     batch.queue(|| PacketRegistry::ConfigurationClientBoundPluginMessage(packet));
 
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_5) {
-        // Send Known Packs
+        // Send Known Packs and wait for the client's response before sending the rest.
+        // The remaining packets (tags, registries, finish) are emitted from the
+        // `ServerBoundKnownPacksPacket` handler once we know whether the client
+        // accepted the vanilla `minecraft:core` pack we offered.
         let packet = ClientBoundKnownPacksPacket::new(protocol_version.humanize());
         batch.queue(|| PacketRegistry::ClientBoundKnownPacks(packet));
+        return Ok(());
     }
+
+    // For 1.20.2 .. 1.20.5, there is no Known Packs handshake — emit the full
+    // configuration burst in one shot (no registries can be skipped).
+    send_post_known_packs_configuration_packets(batch, protocol_version, false)
+}
+
+fn send_post_known_packs_configuration_packets(
+    batch: &mut Batch<PacketRegistry>,
+    protocol_version: ProtocolVersion,
+    client_accepted_vanilla_core: bool,
+) -> Result<(), PacketHandlerError> {
+    let registry_provider = PrecomputedRegistries::new(protocol_version);
 
     // Send tags
     // TODO: Move tags after registry data to match vanilla's behavior
@@ -85,32 +121,36 @@ fn send_configuration_packets(
         batch.queue(|| PacketRegistry::UpdateTags(packet));
     }
 
-    // Send Registry Data
+    // Send Registry Data — skip when the client accepted our vanilla `minecraft:core`
+    // offer, since vanilla clients (and Paper-based servers) treat that as a signal
+    // that the registries are already known.
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_5) {
         let has_registry_data = protocol_version.is_before_inclusive(ProtocolVersion::V1_21_4);
-        // Since 1.20.5, each registry is sent in its own packet
-        batch.chain_iter(
-            registry_provider
-                .get_registry_data_v1_20_5()?
-                .into_iter()
-                .map(move |(registry_id, registry_entries)| {
-                    let packet = RegistryDataPacket::registry(
-                        registry_id,
-                        registry_entries
-                            .iter()
-                            .map(|entry| {
-                                let nbt_bytes = if has_registry_data {
-                                    Some(entry.nbt_bytes.clone())
-                                } else {
-                                    None
-                                };
-                                RegistryEntry::new(entry.entry_id.clone(), nbt_bytes)
-                            })
-                            .collect(),
-                    );
-                    PacketRegistry::RegistryData(packet)
-                }),
-        );
+        if !client_accepted_vanilla_core {
+            // Since 1.20.5, each registry is sent in its own packet
+            batch.chain_iter(
+                registry_provider
+                    .get_registry_data_v1_20_5()?
+                    .into_iter()
+                    .map(|(registry_id, registry_entries)| {
+                        let packet = RegistryDataPacket::registry(
+                            registry_id,
+                            registry_entries
+                                .iter()
+                                .map(|entry| {
+                                    let nbt_bytes = if has_registry_data {
+                                        Some(entry.nbt_bytes.clone())
+                                    } else {
+                                        None
+                                    };
+                                    RegistryEntry::new(entry.entry_id.clone(), nbt_bytes)
+                                })
+                                .collect(),
+                        );
+                        PacketRegistry::RegistryData(packet)
+                    }),
+            );
+        }
     } else if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_2) {
         // Since 1.19, all registries are sent as a single NBT tag
         // Since 1.20.2, all registries are sent in their own packet during the configuration state, still as a single NBT tag
@@ -132,7 +172,8 @@ fn send_configuration_packets(
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use minecraft_protocol::prelude::ProtocolVersion;
+    use minecraft_packets::configuration::data::known_pack::KnownPack;
+    use minecraft_protocol::prelude::{LengthPaddedVec, ProtocolVersion};
 
     fn server_state() -> ServerState {
         ServerState::builder().build().unwrap()
@@ -208,7 +249,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_configuration_packets_v1_20_5() {
+    async fn test_configuration_packets_v1_20_5_initial_sends_only_brand_and_known_packs() {
         // Given
         let mut batch = Batch::new();
 
@@ -225,6 +266,92 @@ mod tests {
             batch.next().await.unwrap(),
             PacketRegistry::ClientBoundKnownPacks(_)
         ));
+        assert!(batch.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_post_known_packs_when_vanilla_rejected_sends_registries() {
+        // Given
+        let mut batch = Batch::new();
+
+        // When
+        send_post_known_packs_configuration_packets(&mut batch, ProtocolVersion::V1_20_5, false)
+            .unwrap();
+        let mut batch = batch.into_stream();
+
+        // Then
+        for _ in 0..4 {
+            assert!(matches!(
+                batch.next().await.unwrap(),
+                PacketRegistry::RegistryData(_)
+            ));
+        }
+        assert!(matches!(
+            batch.next().await.unwrap(),
+            PacketRegistry::FinishConfiguration(_)
+        ));
+        assert!(batch.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_post_known_packs_when_vanilla_accepted_skips_registries() {
+        // Given
+        let mut batch = Batch::new();
+
+        // When
+        send_post_known_packs_configuration_packets(&mut batch, ProtocolVersion::V1_20_5, true)
+            .unwrap();
+        let mut batch = batch.into_stream();
+
+        // Then
+        assert!(matches!(
+            batch.next().await.unwrap(),
+            PacketRegistry::FinishConfiguration(_)
+        ));
+        assert!(batch.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_known_packs_handler_with_matching_core_skips_registries() {
+        // Given
+        let mut client_state = client(ProtocolVersion::V1_20_5);
+        client_state.set_state(State::Configuration);
+        let server_state = server_state();
+        let pkt = ServerBoundKnownPacksPacket {
+            known_packs: LengthPaddedVec::new(vec![KnownPack {
+                namespace: "minecraft".to_string(),
+                id: "core".to_string(),
+                version: ProtocolVersion::V1_20_5.humanize().to_string(),
+            }]),
+        };
+
+        // When
+        let batch = pkt.handle(&mut client_state, &server_state).unwrap();
+        let mut batch = batch.into_stream();
+
+        // Then — no `RegistryData` packets, only `FinishConfiguration`
+        assert!(matches!(
+            batch.next().await.unwrap(),
+            PacketRegistry::FinishConfiguration(_)
+        ));
+        assert!(batch.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_known_packs_handler_with_empty_list_sends_registries() {
+        // Given
+        let mut client_state = client(ProtocolVersion::V1_20_5);
+        client_state.set_state(State::Configuration);
+        let server_state = server_state();
+        let pkt = ServerBoundKnownPacksPacket {
+            known_packs: LengthPaddedVec::new(vec![]),
+        };
+
+        // When
+        let batch = pkt.handle(&mut client_state, &server_state).unwrap();
+        let mut batch = batch.into_stream();
+
+        // Then — registries first, then FinishConfiguration
         for _ in 0..4 {
             assert!(matches!(
                 batch.next().await.unwrap(),

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -86,37 +86,6 @@ fn send_post_known_packs_configuration_packets(
 ) -> Result<(), PacketHandlerError> {
     let registry_provider = PrecomputedRegistries::new(protocol_version);
 
-    // Send tags
-    // TODO: Move tags after registry data to match vanilla's behavior
-    if protocol_version.is_after_inclusive(ProtocolVersion::V1_21_6) {
-        // Since 1.21.6, the Dialog tags should be sent to have server links working
-        // Since 1.21.11, the Timeline tags should be sent to get the time of day working
-        // All tags are sent in a single packet
-        // TODO: `wolf_variant` tags should probably be sent too?
-        let tagged_registries = registry_provider
-            .get_tagged_registries()?
-            .iter()
-            .map(|tagged_registry| {
-                TaggedRegistry::new(
-                    tagged_registry.registry_id.clone(),
-                    tagged_registry
-                        .tags
-                        .iter()
-                        .map(|registry_tag| {
-                            RegistryTag::new(
-                                registry_tag.identifier.clone(),
-                                registry_tag.ids.iter().map(VarInt::from).collect(),
-                            )
-                        })
-                        .collect(),
-                )
-            })
-            .collect();
-
-        let packet = UpdateTagsPacket::new(tagged_registries);
-        batch.queue(|| PacketRegistry::UpdateTags(packet));
-    }
-
     // Send Registry Data — skip when the client accepted our vanilla `minecraft:core`
     // offer, since vanilla clients (and Paper-based servers) treat that as a signal
     // that the registries are already known.
@@ -156,6 +125,36 @@ fn send_post_known_packs_configuration_packets(
     } else {
         // Registries are sent in the Join Game packet for versions prior to 1.20.2 since configuration state does not exist
         unreachable!();
+    }
+
+    // Send tags
+    if protocol_version.is_after_inclusive(ProtocolVersion::V1_21_6) {
+        // Since 1.21.6, the Dialog tags should be sent to have server links working
+        // Since 1.21.11, the Timeline tags should be sent to get the time of day working
+        // All tags are sent in a single packet
+        // TODO: `wolf_variant` tags should probably be sent too?
+        let tagged_registries = registry_provider
+            .get_tagged_registries()?
+            .iter()
+            .map(|tagged_registry| {
+                TaggedRegistry::new(
+                    tagged_registry.registry_id.clone(),
+                    tagged_registry
+                        .tags
+                        .iter()
+                        .map(|registry_tag| {
+                            RegistryTag::new(
+                                registry_tag.identifier.clone(),
+                                registry_tag.ids.iter().map(VarInt::from).collect(),
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+
+        let packet = UpdateTagsPacket::new(tagged_registries);
+        batch.queue(|| PacketRegistry::UpdateTags(packet));
     }
 
     // Send Finished Configuration

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -46,10 +46,7 @@ impl PacketHandler for ServerBoundKnownPacksPacket {
     ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
         let mut batch = Batch::new();
         let protocol_version = client_state.protocol_version();
-        let expected_version = protocol_version.humanize();
-        let client_accepted_vanilla_core = self.known_packs.inner().iter().any(|pack| {
-            pack.namespace == "minecraft" && pack.id == "core" && pack.version == expected_version
-        });
+        let client_accepted_vanilla_core = self.has_minecraft_core();
         send_post_known_packs_configuration_packets(
             &mut batch,
             protocol_version,
@@ -73,14 +70,13 @@ fn send_configuration_packets(
         // The remaining packets (tags, registries, finish) are emitted from the
         // `ServerBoundKnownPacksPacket` handler once we know whether the client
         // accepted the vanilla `minecraft:core` pack we offered.
-        let packet = ClientBoundKnownPacksPacket::new(protocol_version.humanize());
+        let known_packs = protocol_version.known_packs();
+        let packet = ClientBoundKnownPacksPacket::new(known_packs);
         batch.queue(|| PacketRegistry::ClientBoundKnownPacks(packet));
-        return Ok(());
+    } else {
+        send_post_known_packs_configuration_packets(batch, protocol_version, false)?;
     }
-
-    // For 1.20.2 .. 1.20.5, there is no Known Packs handshake — emit the full
-    // configuration burst in one shot (no registries can be skipped).
-    send_post_known_packs_configuration_packets(batch, protocol_version, false)
+    Ok(())
 }
 
 fn send_post_known_packs_configuration_packets(
@@ -125,32 +121,32 @@ fn send_post_known_packs_configuration_packets(
     // offer, since vanilla clients (and Paper-based servers) treat that as a signal
     // that the registries are already known.
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_5) {
-        let has_registry_data = protocol_version.is_before_inclusive(ProtocolVersion::V1_21_4);
-        if !client_accepted_vanilla_core {
-            // Since 1.20.5, each registry is sent in its own packet
-            batch.chain_iter(
-                registry_provider
-                    .get_registry_data_v1_20_5()?
-                    .into_iter()
-                    .map(|(registry_id, registry_entries)| {
-                        let packet = RegistryDataPacket::registry(
-                            registry_id,
-                            registry_entries
-                                .iter()
-                                .map(|entry| {
-                                    let nbt_bytes = if has_registry_data {
-                                        Some(entry.nbt_bytes.clone())
-                                    } else {
-                                        None
-                                    };
-                                    RegistryEntry::new(entry.entry_id.clone(), nbt_bytes)
-                                })
-                                .collect(),
-                        );
-                        PacketRegistry::RegistryData(packet)
-                    }),
-            );
-        }
+        let omit_registry_data = protocol_version.is_after_inclusive(ProtocolVersion::V1_21_5)
+            && client_accepted_vanilla_core;
+
+        // Since 1.20.5, each registry is sent in its own packet
+        batch.chain_iter(
+            registry_provider
+                .get_registry_data_v1_20_5()?
+                .into_iter()
+                .map(move |(registry_id, registry_entries)| {
+                    let packet = RegistryDataPacket::registry(
+                        registry_id,
+                        registry_entries
+                            .iter()
+                            .map(|entry| {
+                                let nbt_bytes = if omit_registry_data {
+                                    None
+                                } else {
+                                    Some(entry.nbt_bytes.clone())
+                                };
+                                RegistryEntry::new(entry.entry_id.clone(), nbt_bytes)
+                            })
+                            .collect(),
+                    );
+                    PacketRegistry::RegistryData(packet)
+                }),
+        );
     } else if protocol_version.is_after_inclusive(ProtocolVersion::V1_20_2) {
         // Since 1.19, all registries are sent as a single NBT tag
         // Since 1.20.2, all registries are sent in their own packet during the configuration state, still as a single NBT tag
@@ -172,8 +168,7 @@ fn send_post_known_packs_configuration_packets(
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use minecraft_packets::configuration::data::known_pack::KnownPack;
-    use minecraft_protocol::prelude::{LengthPaddedVec, ProtocolVersion};
+    use minecraft_protocol::prelude::ProtocolVersion;
 
     fn server_state() -> ServerState {
         ServerState::builder().build().unwrap()
@@ -294,58 +289,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_post_known_packs_when_vanilla_accepted_skips_registries() {
-        // Given
-        let mut batch = Batch::new();
-
-        // When
-        send_post_known_packs_configuration_packets(&mut batch, ProtocolVersion::V1_20_5, true)
-            .unwrap();
-        let mut batch = batch.into_stream();
-
-        // Then
-        assert!(matches!(
-            batch.next().await.unwrap(),
-            PacketRegistry::FinishConfiguration(_)
-        ));
-        assert!(batch.next().await.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_known_packs_handler_with_matching_core_skips_registries() {
-        // Given
-        let mut client_state = client(ProtocolVersion::V1_20_5);
-        client_state.set_state(State::Configuration);
-        let server_state = server_state();
-        let pkt = ServerBoundKnownPacksPacket {
-            known_packs: LengthPaddedVec::new(vec![KnownPack {
-                namespace: "minecraft".to_string(),
-                id: "core".to_string(),
-                version: ProtocolVersion::V1_20_5.humanize().to_string(),
-            }]),
-        };
-
-        // When
-        let batch = pkt.handle(&mut client_state, &server_state).unwrap();
-        let mut batch = batch.into_stream();
-
-        // Then — no `RegistryData` packets, only `FinishConfiguration`
-        assert!(matches!(
-            batch.next().await.unwrap(),
-            PacketRegistry::FinishConfiguration(_)
-        ));
-        assert!(batch.next().await.is_none());
-    }
-
-    #[tokio::test]
     async fn test_known_packs_handler_with_empty_list_sends_registries() {
         // Given
         let mut client_state = client(ProtocolVersion::V1_20_5);
         client_state.set_state(State::Configuration);
         let server_state = server_state();
-        let pkt = ServerBoundKnownPacksPacket {
-            known_packs: LengthPaddedVec::new(vec![]),
-        };
+        let pkt = ServerBoundKnownPacksPacket::new(Vec::new());
 
         // When
         let batch = pkt.handle(&mut client_state, &server_state).unwrap();

--- a/pico_limbo/src/server/packet_registry.rs
+++ b/pico_limbo/src/server/packet_registry.rs
@@ -160,7 +160,7 @@ pub enum PacketRegistry {
         bound = "serverbound",
         name = "minecraft:select_known_packs"
     )]
-    ServerBoundSelectKnownPacks(ServerBoundKnownPacksPacket),
+    ServerBoundKnownPacks(ServerBoundKnownPacksPacket),
 
     #[protocol_id(
         state = "configuration",
@@ -375,12 +375,12 @@ impl PacketHandler for PacketRegistry {
             Self::CustomQueryAnswer(packet) => packet.handle(client_state, server_state),
             Self::LoginAcknowledged(packet) => packet.handle(client_state, server_state),
             Self::AcknowledgeConfiguration(packet) => packet.handle(client_state, server_state),
-            Self::ServerBoundSelectKnownPacks(packet) => packet.handle(client_state, server_state),
             Self::SetPlayerPositionAndRotation(packet) => packet.handle(client_state, server_state),
             Self::SetPlayerPosition(packet) => packet.handle(client_state, server_state),
             Self::ChatCommand(packet) => packet.handle(client_state, server_state),
             Self::ChatMessage(packet) => packet.handle(client_state, server_state),
             Self::ServerBoundPlayerAbilities(packet) => packet.handle(client_state, server_state),
+            Self::ServerBoundKnownPacks(packet) => packet.handle(client_state, server_state),
             _ => Err(PacketHandlerError::custom("Unhandled packet")),
         }
     }

--- a/pico_limbo/src/server/packet_registry.rs
+++ b/pico_limbo/src/server/packet_registry.rs
@@ -8,6 +8,7 @@ use minecraft_packets::configuration::client_bound_known_packs_packet::ClientBou
 use minecraft_packets::configuration::configuration_client_bound_plugin_message_packet::ConfigurationClientBoundPluginMessagePacket;
 use minecraft_packets::configuration::finish_configuration_packet::FinishConfigurationPacket;
 use minecraft_packets::configuration::registry_data_packet::RegistryDataPacket;
+use minecraft_packets::configuration::server_bound_known_packs_packet::ServerBoundKnownPacksPacket;
 use minecraft_packets::configuration::update_tags_packet::UpdateTagsPacket;
 use minecraft_packets::handshaking::handshake_packet::HandshakePacket;
 use minecraft_packets::login::custom_query_answer_packet::CustomQueryAnswerPacket;
@@ -153,6 +154,13 @@ pub enum PacketRegistry {
         name = "minecraft:finish_configuration"
     )]
     AcknowledgeConfiguration(AcknowledgeConfigurationPacket),
+
+    #[protocol_id(
+        state = "configuration",
+        bound = "serverbound",
+        name = "minecraft:select_known_packs"
+    )]
+    ServerBoundSelectKnownPacks(ServerBoundKnownPacksPacket),
 
     #[protocol_id(
         state = "configuration",
@@ -367,6 +375,7 @@ impl PacketHandler for PacketRegistry {
             Self::CustomQueryAnswer(packet) => packet.handle(client_state, server_state),
             Self::LoginAcknowledged(packet) => packet.handle(client_state, server_state),
             Self::AcknowledgeConfiguration(packet) => packet.handle(client_state, server_state),
+            Self::ServerBoundSelectKnownPacks(packet) => packet.handle(client_state, server_state),
             Self::SetPlayerPositionAndRotation(packet) => packet.handle(client_state, server_state),
             Self::SetPlayerPosition(packet) => packet.handle(client_state, server_state),
             Self::ChatCommand(packet) => packet.handle(client_state, server_state),


### PR DESCRIPTION
On 1.20.5+, the server is supposed to wait for the client's `select_known_packs` reply before sending registry data. PicoLimbo currently dumps the whole configuration burst (brand -> known packs -> tags -> all registries -> finish) in one shot from the `LoginAcknowledged` handler, ignoring the client's response entirely. The vanilla client tolerates that, but the bytes for every registry still go on the wire even when the client already has them, and proxies that act on the handshake (Velocity / PE-based plugins) see a protocol that doesn't quite match what a vanilla server does.

### Root cause
`send_configuration_packets` in `login_acknowledged.rs` queued every configuration-state packet in one batch and returned, with no path to inspect the client's `select_known_packs` reply. The serverbound packet wasn't even decoded, there was no `ServerBoundKnownPacksPacket` type and no registry variant for `minecraft:select_known_packs`.

### FIx

Split the configuration burst into two phases:
- **Phase 1**, from `LoginAcknowledged` (1.20.5+): send brand + `ClientBoundKnownPacks` offer (`minecraft:core@<version>`) and stop. For < 1.20.5 (no handshake), the full burst still goes out in one batch, behaviour unchanged.
- **Phase 2**, from the new `ServerBoundKnownPacksPacket` handler: send tags (1.21.6+) + registry data + `FinishConfiguration`. If the client's reply contains `minecraft:core@<expected_version>`, skip the registry data entirely, it matches what vanilla / Paper do when the client claims it already has the built-in pack.

New types / variants:
- `ServerBoundKnownPacksPacket` (`PacketIn`) mirroring the clientbound shape
- `PacketRegistry::ServerBoundSelectKnownPacks` w/ the right state + name attrs
- `KnownPack` fields made `pub` so the handler can match `namespace`/`id`/`version`

### Test
6 unit tests in `pico_limbo/src/handlers/login/login_acknowledged.rs`:

- `test_configuration_packets_v1_20_2` | < 1.20.5 still sends the full burst from phase 1
- `test_configuration_packets_v1_20_5_initial_sends_only_brand_and_known_packs` | phase 1 stops after the offer
- `test_post_known_packs_when_vanilla_rejected_sends_registries` | phase 2 emits registries + finish
- `test_post_known_packs_when_vanilla_accepted_skips_registries` | phase 2 skips registries when the flag is set
- `test_known_packs_handler_with_matching_core_skips_registries` | end-to-end check on the handler w/ a `minecraft:core@<version>` reply
- `test_known_packs_handler_with_empty_list_sends_registries` | end-to-end check w/ an empty reply

### Notes

The version compared against the client reply comes from `protocol_version.humanize()`. That's the same string used by `ClientBoundKnownPacksPacket::new`, so the offer/reply round-trip is internally consistent. If `humanize()` is ever off for a given protocol version (e.g. it ships a Minecraft version label that doesn't match what the client expects in the pack version), the worst case is the client doesn't accept the pack and the handler falls back to sending everything, which is the safe / correct behaviour anyway.

No protocol gating beyond the existing 1.20.5 check is needed. The `select_known_packs` packet only exists from that version onward, and the handler is only reachable when the client has been put into `Configuration` state.
