### PR TITLE
feat(keep-alive): emit keep_alive in CONFIGURATION and make interval configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `keep_alive_interval_seconds` setting (defaults to 15, matching vanilla) to control how often the server sends `keep_alive` packets
+
 ### Fixed
 
 - The plugin doesn't shutdown when shutting down the proxy
 - PicoLimbo should wait for client known packs before sending registry data (starting 1.20.5)
 - Registry data can be omitted if it is known by the client (starting 1.21.5)
+- Send `keep_alive` packets while clients are in the CONFIGURATION state, preventing proxies (e.g. Velocity) from dropping connections with a `read timed out` error during long custom holds
 
 ## [1.12.2+mc26.1.2] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New `keep_alive_interval_seconds` setting (defaults to 15, matching vanilla) to control how often the server sends `keep_alive` packets
+
+### Fixed
+
+- Send `keep_alive` packets while clients are in the CONFIGURATION state, preventing proxies (e.g. Velocity) from dropping connections with a `read timed out` error during long custom holds
+
 ## [1.12.2+mc26.1.2] - 2026-04-12
 
 ### Fixed

--- a/crates/macros/src/packet_reports.rs
+++ b/crates/macros/src/packet_reports.rs
@@ -42,6 +42,7 @@ pub fn packet_report_derive(input: TokenStream) -> TokenStream {
 
     let decode_impl = generate_decode_impl(&variants, &protocol_data);
     let encode_impl = generate_encode_impl(enum_ident, &variants, &protocol_data);
+    let name_impl = generate_packet_name_impl(&variants);
 
     let expanded = quote! {
         #[derive(Debug, thiserror::Error)]
@@ -69,6 +70,7 @@ pub fn packet_report_derive(input: TokenStream) -> TokenStream {
         impl #enum_ident {
             #decode_impl
             #encode_impl
+            #name_impl
         }
     };
 
@@ -320,6 +322,25 @@ fn generate_encode_impl(
                 _ => return Err(PacketRegistryEncodeError::CannotBeEncoded),
             };
             Ok(raw_packet)
+        }
+    }
+}
+
+fn generate_packet_name_impl(variants: &[PacketVariantInfo]) -> proc_macro2::TokenStream {
+    let arms = variants.iter().map(|variant_info| {
+        let variant_ident = &variant_info.variant_ident;
+        let packet_name = &variant_info.name;
+
+        quote! {
+            Self::#variant_ident(_) => #packet_name,
+        }
+    });
+
+    quote! {
+        pub fn packet_name(&self) -> &'static str {
+            match self {
+                #(#arms)*
+            }
         }
     }
 }

--- a/crates/minecraft_protocol/src/lib.rs
+++ b/crates/minecraft_protocol/src/lib.rs
@@ -16,7 +16,7 @@ pub mod prelude {
     pub use crate::packet_serializer::decode_packet::DecodePacket;
     pub use crate::packet_serializer::encode_packet::EncodePacket;
     pub use crate::packet_serializer::packet_id::Identifiable;
-    pub use crate::state::State;
+    pub use crate::state::{Direction, State};
     pub use macros::PacketIn;
     pub use macros::PacketOut;
     pub use pico_binutils::prelude::{

--- a/crates/minecraft_protocol/src/state.rs
+++ b/crates/minecraft_protocol/src/state.rs
@@ -1,6 +1,12 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+#[derive(Copy, Debug, PartialEq, Clone, Eq, Hash)]
+pub enum Direction {
+    Clientbound,
+    Serverbound,
+}
+
 #[derive(Copy, Debug, PartialEq, Clone, Default, Eq, Hash)]
 pub enum State {
     #[default]
@@ -21,6 +27,15 @@ impl Display for State {
             State::Configuration => f.write_str("configuration"),
             State::Play => f.write_str("play"),
             State::Transfer => f.write_str("transfer"),
+        }
+    }
+}
+
+impl Display for Direction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Direction::Clientbound => f.write_str("clientbound"),
+            Direction::Serverbound => f.write_str("serverbound"),
         }
     }
 }

--- a/docs/config/default-configuration.md
+++ b/docs/config/default-configuration.md
@@ -21,6 +21,9 @@ reduced_debug_info = false
 allow_unsupported_versions = false
 allow_flight = false
 accept_transfers = false
+# Interval, in seconds, between two keep-alive packets sent to a client
+# (no effect on clients <= 1.7.6, which use a fixed 2s ping)
+keep_alive_interval_seconds = 15
 
 [forwarding]
 # Disable forwarding

--- a/docs/config/server-settings.md
+++ b/docs/config/server-settings.md
@@ -151,3 +151,18 @@ Whether players who have been transferred from another server via a [transfer pa
 accept_transfers = false
 ```
 :::
+
+## Keep Alive Interval <Badge type="warning" text="1.8+" />
+
+Interval, in seconds, between two `keep_alive` packets sent to a client.
+The default value of `15` matches the vanilla server.
+Lower it (e.g. `10`) if a proxy in front of PicoLimbo has a stricter read-timeout, or if your players have unreliable connections that benefit from more frequent pings.
+
+:::code-group
+```toml [server.toml]
+keep_alive_interval_seconds = 15
+```
+:::
+
+> [!NOTE]
+> Clients on Minecraft 1.7.x use a fixed 2-second ping required by the legacy protocol, regardless of this setting.

--- a/pico_limbo/src/configuration/config.rs
+++ b/pico_limbo/src/configuration/config.rs
@@ -60,6 +60,14 @@ pub struct Config {
 
     pub compression: CompressionConfig,
 
+    /// Interval between two `minecraft:keep_alive` packets sent to a client
+    /// while in CONFIGURATION or PLAY state, in seconds.
+    ///
+    /// Vanilla uses 15. Lower it (e.g. 10) if a proxy in front of `PicoLimbo`
+    /// has a stricter read-timeout. Has no effect on clients <= 1.7.6, which
+    /// use a fixed 2-second ping required by the legacy protocol.
+    pub keep_alive_interval_seconds: u64,
+
     pub tab_list: TabListConfig,
 
     pub fetch_player_skins: bool,
@@ -95,6 +103,7 @@ impl Default for Config {
             reduced_debug_info: false,
             boss_bar: BossBarConfig::default(),
             compression: CompressionConfig::default(),
+            keep_alive_interval_seconds: 15,
             title: TitleConfig::default(),
             allow_unsupported_versions: false,
             allow_flight: false,

--- a/pico_limbo/src/handlers/configuration.rs
+++ b/pico_limbo/src/handlers/configuration.rs
@@ -248,7 +248,6 @@ pub fn send_play_packets(
     }
 
     client_state.set_state(State::Play);
-    client_state.set_keep_alive_should_enable();
 
     Ok(())
 }

--- a/pico_limbo/src/handlers/configuration.rs
+++ b/pico_limbo/src/handlers/configuration.rs
@@ -45,7 +45,7 @@ impl PacketHandler for AcknowledgeConfigurationPacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         send_play_packets(&mut batch, client_state, server_state)?;
         Ok(batch)
@@ -130,7 +130,7 @@ impl From<SchematicError> for PacketHandlerError {
 }
 
 pub fn send_play_packets(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     client_state: &mut ClientState,
     server_state: &ServerState,
 ) -> Result<(), PacketHandlerError> {
@@ -252,14 +252,14 @@ pub fn send_play_packets(
     Ok(())
 }
 
-fn send_tab_list_packets(batch: &mut Batch<PacketRegistry>, server_state: &ServerState) {
+fn send_tab_list_packets(batch: &mut Batch, server_state: &ServerState) {
     if let Some(TabList { header, footer }) = server_state.tab_list() {
         let packet = TabListPacket::new(header, footer);
         batch.queue(|| PacketRegistry::TabList(packet));
     }
 }
 
-fn send_boss_bar_packets(batch: &mut Batch<PacketRegistry>, server_state: &ServerState) {
+fn send_boss_bar_packets(batch: &mut Batch, server_state: &ServerState) {
     if let Some(boss_bar) = server_state.boss_bar() {
         let packet = BossBarPacket::add(
             &boss_bar.title,
@@ -272,7 +272,7 @@ fn send_boss_bar_packets(batch: &mut Batch<PacketRegistry>, server_state: &Serve
 }
 
 fn send_title_text_packets(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     server_state: &ServerState,
     protocol_version: ProtocolVersion,
 ) {
@@ -328,7 +328,7 @@ fn send_title_text_packets(
 }
 
 fn send_action_bar_packet(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     server_state: &ServerState,
     protocol_version: ProtocolVersion,
 ) {
@@ -347,7 +347,7 @@ fn send_action_bar_packet(
 }
 
 fn send_skin_packets(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     client_state: &ClientState,
     server_state: &ServerState,
 ) {
@@ -396,7 +396,7 @@ fn send_skin_packets(
 }
 
 fn send_commands_packet(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     protocol_version: ProtocolVersion,
     server_state: &ServerState,
 ) {
@@ -436,7 +436,7 @@ impl From<TryFromIntError> for PacketHandlerError {
 }
 
 pub fn send_message(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     component: &Component,
     protocol_version: ProtocolVersion,
 ) {

--- a/pico_limbo/src/handlers/configuration.rs
+++ b/pico_limbo/src/handlers/configuration.rs
@@ -134,6 +134,7 @@ pub fn send_play_packets(
     client_state: &mut ClientState,
     server_state: &ServerState,
 ) -> Result<(), PacketHandlerError> {
+    batch.queue_both_state_change(State::Play);
     let protocol_version = client_state.protocol_version();
     let view_distance = server_state.view_distance();
     let dimension = server_state.spawn_dimension();
@@ -247,8 +248,6 @@ pub fn send_play_packets(
         batch.chain_iter(iter);
     }
 
-    client_state.set_state(State::Play);
-
     Ok(())
 }
 
@@ -346,11 +345,7 @@ fn send_action_bar_packet(
     }
 }
 
-fn send_skin_packets(
-    batch: &mut Batch,
-    client_state: &ClientState,
-    server_state: &ServerState,
-) {
+fn send_skin_packets(batch: &mut Batch, client_state: &ClientState, server_state: &ServerState) {
     let fetch_player_skins = server_state.fetch_player_skins();
     let is_player_listed = server_state.is_player_listed();
     let unique_id = client_state.get_unique_id();
@@ -435,11 +430,7 @@ impl From<TryFromIntError> for PacketHandlerError {
     }
 }
 
-pub fn send_message(
-    batch: &mut Batch,
-    component: &Component,
-    protocol_version: ProtocolVersion,
-) {
+pub fn send_message(batch: &mut Batch, component: &Component, protocol_version: ProtocolVersion) {
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_19) {
         let packet = SystemChatMessagePacket::component(component);
         batch.queue(|| PacketRegistry::SystemChatMessage(packet));
@@ -452,12 +443,19 @@ pub fn send_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::batch::BatchStream;
     use futures::StreamExt;
+    use minecraft_protocol::prelude::Direction;
 
     fn server_state() -> ServerState {
         let mut builder = ServerState::builder();
         builder.view_distance(0).welcome_message("Hello, World!");
         builder.build().unwrap()
+    }
+
+    async fn assert_play_state(batch: &mut BatchStream) {
+        batch.assert_client_state(State::Play).await;
+        batch.assert_server_state(State::Play).await;
     }
 
     fn client(protocol: ProtocolVersion) -> ClientState {
@@ -468,7 +466,8 @@ mod tests {
         } else {
             State::Login
         };
-        cs.set_state(previous_state);
+        cs.set_state(Direction::Clientbound, previous_state);
+        cs.set_state(Direction::Serverbound, previous_state);
         cs
     }
 
@@ -484,48 +483,49 @@ mod tests {
         let mut batch = batch.into_stream();
 
         // Then
+        assert_play_state(&mut batch).await;
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::Login(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ClientBoundPlayerAbilities(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SetDefaultSpawnPosition(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SynchronizePlayerPosition(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::Commands(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SystemChatMessage(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::UpdateTime(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SetEntityMetadata(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::GameEvent(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SetCenterChunk(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ChunkDataAndUpdateLight(_)
         ));
         assert!(batch.next().await.is_none());
@@ -543,48 +543,49 @@ mod tests {
         let mut batch = batch.into_stream();
 
         // Then
+        assert_play_state(&mut batch).await;
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::Login(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ClientBoundPlayerAbilities(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SetDefaultSpawnPosition(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SynchronizePlayerPosition(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::Commands(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::PlayClientBoundPluginMessage(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SystemChatMessage(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::UpdateTime(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SetEntityMetadata(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SetCenterChunk(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ChunkDataAndUpdateLight(_)
         ));
         assert!(batch.next().await.is_none());
@@ -602,36 +603,37 @@ mod tests {
         let mut batch = batch.into_stream();
 
         // Then
+        assert_play_state(&mut batch).await;
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::Login(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ClientBoundPlayerAbilities(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SynchronizePlayerPosition(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::Commands(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::PlayClientBoundPluginMessage(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::LegacyChatMessage(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::UpdateTime(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SetEntityMetadata(_)
         ));
         assert!(batch.next().await.is_none());
@@ -649,28 +651,29 @@ mod tests {
         let mut batch = batch.into_stream();
 
         // Then
+        assert_play_state(&mut batch).await;
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::Login(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ClientBoundPlayerAbilities(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SynchronizePlayerPosition(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::LegacyChatMessage(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::UpdateTime(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SetEntityMetadata(_)
         ));
         assert!(batch.next().await.is_none());

--- a/pico_limbo/src/handlers/handshake.rs
+++ b/pico_limbo/src/handlers/handshake.rs
@@ -5,7 +5,6 @@ use crate::server::batch::Batch;
 use crate::server::client_state::ClientState;
 use crate::server::game_profile::GameProfile;
 use crate::server::packet_handler::{PacketHandler, PacketHandlerError};
-use crate::server::packet_registry::PacketRegistry;
 use crate::server_state::ServerState;
 use minecraft_packets::handshaking::handshake_packet::HandshakePacket;
 use minecraft_protocol::prelude::{ProtocolVersion, State};
@@ -17,7 +16,7 @@ impl PacketHandler for HandshakePacket {
         client_state: &mut ClientState,
         server_state: &ServerState,
     ) -> Result<Batch, PacketHandlerError> {
-        let batch = Batch::new();
+        let mut batch = Batch::new();
         client_state
             .set_protocol_version(self.get_protocol(server_state.allow_unsupported_versions()));
 
@@ -29,7 +28,7 @@ impl PacketHandler for HandshakePacket {
                 )))
             },
             |next_state| {
-                client_state.set_state(next_state);
+                batch.queue_both_state_change(next_state);
 
                 match next_state {
                     State::Status => {
@@ -45,7 +44,7 @@ impl PacketHandler for HandshakePacket {
                     }
                     State::Transfer => {
                         if server_state.accept_transfers() {
-                            client_state.set_state(State::Login);
+                            batch.queue_both_state_change(State::Login);
                             begin_login(client_state, server_state, &self.hostname)?;
                             Ok(batch)
                         } else {
@@ -144,8 +143,8 @@ mod tests {
         server_state_builder.build().unwrap()
     }
 
-    #[test]
-    fn test_handshake_handler_should_update_client_state_to_login() {
+    #[tokio::test]
+    async fn test_handshake_handler_should_update_client_state_to_login() {
         // Given
         let mut client_state = ClientState::default();
         let handshake_packet = HandshakePacket {
@@ -156,16 +155,18 @@ mod tests {
         };
 
         // When
-        handshake_packet
+        let mut batch = handshake_packet
             .handle(&mut client_state, &server_state())
-            .unwrap();
+            .unwrap()
+            .into_stream();
 
         // Then
-        assert_eq!(client_state.state(), State::Login);
+        batch.assert_client_state(State::Login).await;
+        batch.assert_server_state(State::Login).await;
     }
 
-    #[test]
-    fn test_handshake_handler_should_update_client_state_to_status() {
+    #[tokio::test]
+    async fn test_handshake_handler_should_update_client_state_to_status() {
         // Given
         let mut client_state = ClientState::default();
         let handshake_packet = HandshakePacket {
@@ -176,12 +177,14 @@ mod tests {
         };
 
         // When
-        handshake_packet
+        let mut batch = handshake_packet
             .handle(&mut client_state, &server_state())
-            .unwrap();
+            .unwrap()
+            .into_stream();
 
         // Then
-        assert_eq!(client_state.state(), State::Status);
+        batch.assert_client_state(State::Status).await;
+        batch.assert_server_state(State::Status).await;
     }
 
     #[test]
@@ -225,8 +228,8 @@ mod tests {
         assert_eq!(client_state.protocol_version(), ProtocolVersion::V1_15_2);
     }
 
-    #[test]
-    fn test_handshake_handler_should_change_state_when_bungee_cord_handshake_is_valid() {
+    #[tokio::test]
+    async fn test_handshake_handler_should_change_state_when_bungee_cord_handshake_is_valid() {
         // Given
         let mut client_state = ClientState::default();
         let handshake_packet = HandshakePacket {
@@ -237,12 +240,14 @@ mod tests {
         };
 
         // When
-        handshake_packet
+        let mut batch = handshake_packet
             .handle(&mut client_state, &bungee_cord())
-            .unwrap();
+            .unwrap()
+            .into_stream();
 
         // Then
-        assert_eq!(client_state.state(), State::Login);
+        batch.assert_client_state(State::Login).await;
+        batch.assert_server_state(State::Login).await;
     }
 
     #[test]
@@ -270,8 +275,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_handshake_handler_update_state_to_status_when_bungee_cord_is_enabled() {
+    #[tokio::test]
+    async fn test_handshake_handler_update_state_to_status_when_bungee_cord_is_enabled() {
         // Given
         let mut client_state = ClientState::default();
         let handshake_packet = HandshakePacket {
@@ -282,11 +287,13 @@ mod tests {
         };
 
         // When
-        handshake_packet
+        let mut batch = handshake_packet
             .handle(&mut client_state, &bungee_cord())
-            .unwrap();
+            .unwrap()
+            .into_stream();
 
         // Then
-        assert_eq!(client_state.state(), State::Status);
+        batch.assert_client_state(State::Status).await;
+        batch.assert_server_state(State::Status).await;
     }
 }

--- a/pico_limbo/src/handlers/handshake.rs
+++ b/pico_limbo/src/handlers/handshake.rs
@@ -16,7 +16,7 @@ impl PacketHandler for HandshakePacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let batch = Batch::new();
         client_state
             .set_protocol_version(self.get_protocol(server_state.allow_unsupported_versions()));

--- a/pico_limbo/src/handlers/login/custom_query_answer.rs
+++ b/pico_limbo/src/handlers/login/custom_query_answer.rs
@@ -16,7 +16,7 @@ impl PacketHandler for CustomQueryAnswerPacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         let client_message_id = client_state.get_velocity_login_message_id();
 

--- a/pico_limbo/src/handlers/login/custom_query_answer.rs
+++ b/pico_limbo/src/handlers/login/custom_query_answer.rs
@@ -6,7 +6,6 @@ use crate::server::batch::Batch;
 use crate::server::client_state::ClientState;
 use crate::server::game_profile::GameProfile;
 use crate::server::packet_handler::{PacketHandler, PacketHandlerError};
-use crate::server::packet_registry::PacketRegistry;
 use crate::server_state::ServerState;
 use minecraft_packets::login::custom_query_answer_packet::CustomQueryAnswerPacket;
 use minecraft_protocol::prelude::BinaryReader;

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -23,7 +23,7 @@ impl PacketHandler for LoginAcknowledgedPacket {
         &self,
         client_state: &mut ClientState,
         _server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         let protocol_version = client_state.protocol_version();
         if protocol_version.supports_configuration_state() {
@@ -59,7 +59,7 @@ impl PacketHandler for ServerBoundKnownPacksPacket {
 
 /// Only for >= 1.20.2
 fn send_configuration_packets(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     protocol_version: ProtocolVersion,
 ) -> Result<(), PacketHandlerError> {
     // Send Server Brand

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -27,7 +27,6 @@ impl PacketHandler for LoginAcknowledgedPacket {
         let mut batch = Batch::new();
         let protocol_version = client_state.protocol_version();
         if protocol_version.supports_configuration_state() {
-            client_state.set_state(State::Configuration);
             client_state.set_keep_alive_should_enable();
             send_configuration_packets(&mut batch, protocol_version)?;
             Ok(batch)
@@ -44,7 +43,7 @@ impl PacketHandler for ServerBoundKnownPacksPacket {
         &self,
         client_state: &mut ClientState,
         _server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         let protocol_version = client_state.protocol_version();
         let client_accepted_vanilla_core = self.has_minecraft_core();
@@ -62,6 +61,8 @@ fn send_configuration_packets(
     batch: &mut Batch,
     protocol_version: ProtocolVersion,
 ) -> Result<(), PacketHandlerError> {
+    batch.queue_both_state_change(State::Configuration);
+
     // Send Server Brand
     let packet = ConfigurationClientBoundPluginMessagePacket::brand(SERVER_BRAND);
     batch.queue(|| PacketRegistry::ConfigurationClientBoundPluginMessage(packet));
@@ -81,7 +82,7 @@ fn send_configuration_packets(
 }
 
 fn send_post_known_packs_configuration_packets(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     protocol_version: ProtocolVersion,
     client_accepted_vanilla_core: bool,
 ) -> Result<(), PacketHandlerError> {
@@ -161,6 +162,7 @@ fn send_post_known_packs_configuration_packets(
     // Send Finished Configuration
     let packet = FinishConfigurationPacket {};
     batch.queue(|| PacketRegistry::FinishConfiguration(packet));
+    batch.queue_clientbound_state_change(State::Play);
     Ok(())
 }
 
@@ -168,7 +170,7 @@ fn send_post_known_packs_configuration_packets(
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use minecraft_protocol::prelude::ProtocolVersion;
+    use minecraft_protocol::prelude::{Direction, ProtocolVersion};
 
     fn server_state() -> ServerState {
         ServerState::builder().build().unwrap()
@@ -177,7 +179,8 @@ mod tests {
     fn client(protocol: ProtocolVersion) -> ClientState {
         let mut cs = ClientState::default();
         cs.set_protocol_version(protocol);
-        cs.set_state(State::Login);
+        cs.set_state(Direction::Clientbound, State::Login);
+        cs.set_state(Direction::Serverbound, State::Login);
         cs
     }
 
@@ -197,7 +200,7 @@ mod tests {
         let mut batch = batch.into_stream();
 
         // Then
-        assert_eq!(client_state.state(), State::Configuration);
+        batch.assert_client_state(State::Configuration).await;
         assert!(client_state.should_enable_keep_alive());
         assert!(batch.next().await.is_some());
     }
@@ -229,18 +232,21 @@ mod tests {
         let mut batch = batch.into_stream();
 
         // Then
+        batch.assert_client_state(State::Configuration).await;
+        batch.assert_server_state(State::Configuration).await;
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ConfigurationClientBoundPluginMessage(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::RegistryData(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::FinishConfiguration(_)
         ));
+        batch.assert_client_state(State::Play).await;
         assert!(batch.next().await.is_none());
     }
 
@@ -254,12 +260,14 @@ mod tests {
         let mut batch = batch.into_stream();
 
         // Then
+        batch.assert_client_state(State::Configuration).await;
+        batch.assert_server_state(State::Configuration).await;
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ConfigurationClientBoundPluginMessage(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::ClientBoundKnownPacks(_)
         ));
         assert!(batch.next().await.is_none());
@@ -278,14 +286,15 @@ mod tests {
         // Then
         for _ in 0..4 {
             assert!(matches!(
-                batch.next().await.unwrap(),
+                batch.next().await.unwrap().unwrap_packet(),
                 PacketRegistry::RegistryData(_)
             ));
         }
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::FinishConfiguration(_)
         ));
+        batch.assert_client_state(State::Play).await;
         assert!(batch.next().await.is_none());
     }
 
@@ -293,7 +302,8 @@ mod tests {
     async fn test_known_packs_handler_with_empty_list_sends_registries() {
         // Given
         let mut client_state = client(ProtocolVersion::V1_20_5);
-        client_state.set_state(State::Configuration);
+        client_state.set_state(Direction::Clientbound, State::Configuration);
+        client_state.set_state(Direction::Serverbound, State::Configuration);
         let server_state = server_state();
         let pkt = ServerBoundKnownPacksPacket::new(Vec::new());
 
@@ -301,17 +311,18 @@ mod tests {
         let batch = pkt.handle(&mut client_state, &server_state).unwrap();
         let mut batch = batch.into_stream();
 
-        // Then — registries first, then FinishConfiguration
+        // Then, registries first, then FinishConfiguration
         for _ in 0..4 {
             assert!(matches!(
-                batch.next().await.unwrap(),
+                batch.next().await.unwrap().unwrap_packet(),
                 PacketRegistry::RegistryData(_)
             ));
         }
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::FinishConfiguration(_)
         ));
+        batch.assert_client_state(State::Play).await;
         assert!(batch.next().await.is_none());
     }
 }

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -27,6 +27,7 @@ impl PacketHandler for LoginAcknowledgedPacket {
         let protocol_version = client_state.protocol_version();
         if protocol_version.supports_configuration_state() {
             client_state.set_state(State::Configuration);
+            client_state.set_keep_alive_should_enable();
             send_configuration_packets(&mut batch, protocol_version)?;
             Ok(batch)
         } else {
@@ -155,6 +156,7 @@ mod tests {
 
         // Then
         assert_eq!(client_state.state(), State::Configuration);
+        assert!(client_state.should_enable_keep_alive());
         assert!(batch.next().await.is_some());
     }
 

--- a/pico_limbo/src/handlers/login/login_acknowledged.rs
+++ b/pico_limbo/src/handlers/login/login_acknowledged.rs
@@ -28,6 +28,7 @@ impl PacketHandler for LoginAcknowledgedPacket {
         let protocol_version = client_state.protocol_version();
         if protocol_version.supports_configuration_state() {
             client_state.set_state(State::Configuration);
+            client_state.set_keep_alive_should_enable();
             send_configuration_packets(&mut batch, protocol_version)?;
             Ok(batch)
         } else {
@@ -197,6 +198,7 @@ mod tests {
 
         // Then
         assert_eq!(client_state.state(), State::Configuration);
+        assert!(client_state.should_enable_keep_alive());
         assert!(batch.next().await.is_some());
     }
 

--- a/pico_limbo/src/handlers/login/login_start.rs
+++ b/pico_limbo/src/handlers/login/login_start.rs
@@ -72,6 +72,7 @@ pub fn fire_login_success(
     client_state.set_game_profile(game_profile);
 
     if !protocol_version.supports_configuration_state() {
+        client_state.set_keep_alive_should_enable();
         send_play_packets(batch, client_state, server_state)?;
     }
     Ok(())

--- a/pico_limbo/src/handlers/login/login_start.rs
+++ b/pico_limbo/src/handlers/login/login_start.rs
@@ -59,6 +59,7 @@ pub fn fire_login_success(
         let threshold = compression_settings.threshold;
         let packet = SetCompressionPacket::new(i32::try_from(threshold)?);
         batch.queue(|| PacketRegistry::SetCompression(packet));
+        batch.queue_enable_compression();
     }
 
     if protocol_version.is_after_inclusive(ProtocolVersion::V1_21_2) {
@@ -82,7 +83,7 @@ pub fn fire_login_success(
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use minecraft_protocol::prelude::{ProtocolVersion, State};
+    use minecraft_protocol::prelude::{Direction, ProtocolVersion, State};
 
     fn vanilla() -> ServerState {
         ServerState::builder().build().unwrap()
@@ -98,7 +99,8 @@ mod tests {
     pub fn client(protocol: ProtocolVersion) -> ClientState {
         let mut cs = ClientState::default();
         cs.set_protocol_version(protocol);
-        cs.set_state(State::Login);
+        cs.set_state(Direction::Clientbound, State::Login);
+        cs.set_state(Direction::Serverbound, State::Login);
         cs
     }
 
@@ -120,7 +122,10 @@ mod tests {
 
         // Then
         assert!(
-            matches!(batch.next().await.unwrap(), PacketRegistry::CustomQuery(_)),
+            matches!(
+                batch.next().await.unwrap().unwrap_packet(),
+                PacketRegistry::CustomQuery(_)
+            ),
             "first packet should be the velocity CustomQuery"
         );
         assert_ne!(client_state.get_velocity_login_message_id(), -1);
@@ -160,7 +165,10 @@ mod tests {
 
         // Then
         assert!(
-            matches!(batch.next().await.unwrap(), PacketRegistry::LoginSuccess(_)),
+            matches!(
+                batch.next().await.unwrap().unwrap_packet(),
+                PacketRegistry::LoginSuccess(_)
+            ),
             "first packet should be LoginSuccess for ≥ 1.21.2"
         );
     }
@@ -178,7 +186,10 @@ mod tests {
 
         // Then
         assert!(
-            matches!(batch.next().await.unwrap(), PacketRegistry::GameProfile(_)),
+            matches!(
+                batch.next().await.unwrap().unwrap_packet(),
+                PacketRegistry::GameProfile(_)
+            ),
             "first packet should be GameProfile for < 1.21.2"
         );
     }

--- a/pico_limbo/src/handlers/login/login_start.rs
+++ b/pico_limbo/src/handlers/login/login_start.rs
@@ -19,7 +19,7 @@ impl PacketHandler for LoginStartPacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         if server_state.is_modern_forwarding() {
             if client_state.protocol_version().is_modern() {
@@ -35,7 +35,7 @@ impl PacketHandler for LoginStartPacket {
     }
 }
 
-fn login_start_velocity(batch: &mut Batch<PacketRegistry>, client_state: &mut ClientState) {
+fn login_start_velocity(batch: &mut Batch, client_state: &mut ClientState) {
     let message_id = {
         let mut rng = rand::rng();
         rng.random()
@@ -46,7 +46,7 @@ fn login_start_velocity(batch: &mut Batch<PacketRegistry>, client_state: &mut Cl
 }
 
 pub fn fire_login_success(
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
     client_state: &mut ClientState,
     server_state: &ServerState,
     game_profile: GameProfile,

--- a/pico_limbo/src/handlers/play/commands.rs
+++ b/pico_limbo/src/handlers/play/commands.rs
@@ -17,7 +17,7 @@ impl PacketHandler for ChatCommandPacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         run_command(client_state, server_state, self.get_command(), &mut batch);
         Ok(batch)
@@ -29,7 +29,7 @@ impl PacketHandler for ChatMessagePacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         if let Some(command) = self.get_command() {
             run_command(client_state, server_state, command, &mut batch);
@@ -44,7 +44,7 @@ fn run_command(
     client_state: &mut ClientState,
     server_state: &ServerState,
     command: &str,
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
 ) {
     info!(
         "{} issued server command: /{}",

--- a/pico_limbo/src/handlers/play/player_abilities.rs
+++ b/pico_limbo/src/handlers/play/player_abilities.rs
@@ -1,7 +1,6 @@
 use crate::server::batch::Batch;
 use crate::server::client_state::ClientState;
 use crate::server::packet_handler::{PacketHandler, PacketHandlerError};
-use crate::server::packet_registry::PacketRegistry;
 use crate::server_state::ServerState;
 use minecraft_packets::play::server_bound_player_abilities_packet::ServerBoundPlayerAbilitiesPacket;
 

--- a/pico_limbo/src/handlers/play/player_abilities.rs
+++ b/pico_limbo/src/handlers/play/player_abilities.rs
@@ -10,7 +10,7 @@ impl PacketHandler for ServerBoundPlayerAbilitiesPacket {
         &self,
         client_state: &mut ClientState,
         _server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         client_state.set_is_flying(self.is_flying());
         Ok(Batch::new())
     }

--- a/pico_limbo/src/handlers/play/set_player_pos.rs
+++ b/pico_limbo/src/handlers/play/set_player_pos.rs
@@ -11,7 +11,7 @@ impl PacketHandler for SetPlayerPositionPacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         Ok(teleport_player_to_spawn_out_of_bounds(
             client_state,
             server_state,

--- a/pico_limbo/src/handlers/play/set_player_pos.rs
+++ b/pico_limbo/src/handlers/play/set_player_pos.rs
@@ -2,7 +2,6 @@ use crate::handlers::play::set_player_position_and_rotation::teleport_player_to_
 use crate::server::batch::Batch;
 use crate::server::client_state::ClientState;
 use crate::server::packet_handler::{PacketHandler, PacketHandlerError};
-use crate::server::packet_registry::PacketRegistry;
 use crate::server_state::ServerState;
 use minecraft_packets::play::set_player_position_packet::SetPlayerPositionPacket;
 

--- a/pico_limbo/src/handlers/play/set_player_position_and_rotation.rs
+++ b/pico_limbo/src/handlers/play/set_player_position_and_rotation.rs
@@ -14,7 +14,7 @@ impl PacketHandler for SetPlayerPositionAndRotationPacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         Ok(teleport_player_to_spawn_out_of_bounds(
             client_state,
             server_state,
@@ -27,7 +27,7 @@ pub fn teleport_player_to_spawn_out_of_bounds(
     client_state: &mut ClientState,
     server_state: &ServerState,
     feet_y: f64,
-) -> Batch<PacketRegistry> {
+) -> Batch {
     let mut batch = Batch::new();
     if let Some(Boundaries {
         teleport_message,
@@ -58,7 +58,7 @@ pub fn teleport_player_to_spawn_out_of_bounds(
 pub fn teleport_player_to_spawn(
     client_state: &mut ClientState,
     server_state: &ServerState,
-    batch: &mut Batch<PacketRegistry>,
+    batch: &mut Batch,
 ) {
     let (x, y, z) = server_state.spawn_position();
     let (yaw, pitch) = server_state.spawn_rotation();

--- a/pico_limbo/src/handlers/play/set_player_position_and_rotation.rs
+++ b/pico_limbo/src/handlers/play/set_player_position_and_rotation.rs
@@ -72,7 +72,7 @@ pub fn teleport_player_to_spawn(
 mod tests {
     use super::*;
     use futures::StreamExt;
-    use minecraft_protocol::prelude::{ProtocolVersion, State};
+    use minecraft_protocol::prelude::{Direction, ProtocolVersion, State};
 
     fn server_state_with_min_y(min_y: i32, message: Option<String>) -> ServerState {
         let mut builder = ServerState::builder();
@@ -89,7 +89,8 @@ mod tests {
     fn client_state() -> ClientState {
         let mut cs = ClientState::default();
         cs.set_protocol_version(ProtocolVersion::V1_20_5);
-        cs.set_state(State::Play);
+        cs.set_state(Direction::Clientbound, State::Play);
+        cs.set_state(Direction::Serverbound, State::Play);
         cs
     }
 
@@ -105,11 +106,11 @@ mod tests {
 
         // Then
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SynchronizePlayerPosition(_)
         ));
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SystemChatMessage(_) | PacketRegistry::LegacyChatMessage(_)
         ));
         assert!(batch.next().await.is_none());
@@ -127,7 +128,7 @@ mod tests {
 
         // Then
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::SynchronizePlayerPosition(_)
         ));
         assert!(batch.next().await.is_none());
@@ -187,7 +188,7 @@ mod tests {
 
         assert!(
             matches!(
-                stream2.next().await.unwrap(),
+                stream2.next().await.unwrap().unwrap_packet(),
                 PacketRegistry::SynchronizePlayerPosition(_)
             ),
             "Second packet should trigger a teleport"

--- a/pico_limbo/src/handlers/status/ping_request.rs
+++ b/pico_limbo/src/handlers/status/ping_request.rs
@@ -11,7 +11,7 @@ impl PacketHandler for PingRequestPacket {
         &self,
         _client_state: &mut ClientState,
         _server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         let packet = PongResponsePacket {
             timestamp: self.timestamp,

--- a/pico_limbo/src/handlers/status/ping_request.rs
+++ b/pico_limbo/src/handlers/status/ping_request.rs
@@ -41,7 +41,7 @@ mod tests {
 
         // Then
         assert!(matches!(
-            batch.next().await.unwrap(),
+            batch.next().await.unwrap().unwrap_packet(),
             PacketRegistry::PongResponse(_)
         ));
         assert!(batch.next().await.is_none());

--- a/pico_limbo/src/handlers/status/status_request.rs
+++ b/pico_limbo/src/handlers/status/status_request.rs
@@ -13,7 +13,7 @@ impl PacketHandler for StatusRequestPacket {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         let mut batch = Batch::new();
         let client_protocol_version = client_state.protocol_version();
         let (version_string, version_number) =

--- a/pico_limbo/src/handlers/status/status_request.rs
+++ b/pico_limbo/src/handlers/status/status_request.rs
@@ -82,8 +82,8 @@ mod tests {
         // Then
         let packet = batch.next().await.unwrap();
         assert!(matches!(
-          packet,
-          PacketRegistry::StatusResponse(ref status_packet)
+          packet.unwrap_packet(),
+          PacketRegistry::StatusResponse( status_packet)
            if status_packet.status_response().unwrap().version.protocol == expected_protocol
         ));
         assert!(batch.next().await.is_none());
@@ -106,8 +106,8 @@ mod tests {
         // Then
         let packet = batch.next().await.unwrap();
         assert!(matches!(
-          packet,
-          PacketRegistry::StatusResponse(ref status_packet)
+          packet.unwrap_packet(),
+          PacketRegistry::StatusResponse( status_packet)
            if status_packet.status_response().unwrap().version.protocol == expected_protocol
         ));
         assert!(batch.next().await.is_none());
@@ -130,8 +130,8 @@ mod tests {
         // Then
         let packet = batch.next().await.unwrap();
         assert!(matches!(
-          packet,
-          PacketRegistry::StatusResponse(ref status_packet)
+          packet.unwrap_packet(),
+          PacketRegistry::StatusResponse(status_packet)
            if status_packet.status_response().unwrap().version.protocol == ProtocolVersion::latest().version_number()
         ));
         assert!(batch.next().await.is_none());
@@ -156,8 +156,8 @@ mod tests {
             // Then
             let packet = batch.next().await.unwrap();
             assert!(matches!(
-                packet,
-                PacketRegistry::StatusResponse(ref status_packet)
+                packet.unwrap_packet(),
+                PacketRegistry::StatusResponse(status_packet)
                     if status_packet.status_response().unwrap().version.protocol ==
                         ProtocolVersion::V1_7_2.version_number()
             ));

--- a/pico_limbo/src/server/batch.rs
+++ b/pico_limbo/src/server/batch.rs
@@ -1,5 +1,6 @@
 use crate::server::packet_registry::PacketRegistry;
 use futures::stream::Stream;
+use minecraft_protocol::prelude::{Direction, State};
 use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
@@ -12,6 +13,8 @@ enum Producer {
     SyncClosure(Box<dyn FnOnce() -> PacketRegistry + Send + 'static>),
     AsyncClosure(AsyncClosure),
     Iterator(Box<dyn Iterator<Item = PacketRegistry> + Send + 'static>),
+    StateChange(Direction, State),
+    EnableCompression,
 }
 
 pub struct Batch {
@@ -23,6 +26,28 @@ impl Batch {
         Self {
             producers: VecDeque::new(),
         }
+    }
+
+    pub fn queue_enable_compression(&mut self) {
+        self.producers.push_back(Producer::EnableCompression);
+    }
+
+    /// Queue a state change for both directions. All received and sent packets will use the new state.
+    pub fn queue_both_state_change(&mut self, new_state: State) {
+        self.queue_clientbound_state_change(new_state);
+        self.queue_serverbound_state_change(new_state);
+    }
+
+    /// Queue a state change for sent packets.
+    pub fn queue_clientbound_state_change(&mut self, new_state: State) {
+        self.producers
+            .push_back(Producer::StateChange(Direction::Clientbound, new_state));
+    }
+
+    /// Queue a state change for received packets.
+    pub fn queue_serverbound_state_change(&mut self, new_state: State) {
+        self.producers
+            .push_back(Producer::StateChange(Direction::Serverbound, new_state));
     }
 
     /// Queues a synchronous function or closure.
@@ -39,7 +64,8 @@ impl Batch {
         F: FnOnce() -> Fut + Send + 'static,
         Fut: Future<Output = PacketRegistry> + Send + 'static,
     {
-        let closure = move || -> Pin<Box<dyn Future<Output = PacketRegistry> + Send>> { Box::pin(f()) };
+        let closure =
+            move || -> Pin<Box<dyn Future<Output = PacketRegistry> + Send>> { Box::pin(f()) };
         self.producers
             .push_back(Producer::AsyncClosure(Box::new(closure)));
     }
@@ -73,8 +99,14 @@ pub struct BatchStream {
     current: Current,
 }
 
+pub enum BatchItem {
+    Packet(PacketRegistry),
+    StateChange(Direction, State),
+    EnableCompression,
+}
+
 impl Stream for BatchStream {
-    type Item = PacketRegistry;
+    type Item = BatchItem;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -85,20 +117,26 @@ impl Stream for BatchStream {
                     return match fut.as_mut().poll(cx) {
                         Poll::Ready(item) => {
                             this.current = Current::Idle;
-                            Poll::Ready(Some(item))
+                            Poll::Ready(Some(BatchItem::Packet(item)))
                         }
                         Poll::Pending => Poll::Pending,
                     };
                 }
                 Current::Iterator(iter) => {
                     if let Some(item) = iter.next() {
-                        return Poll::Ready(Some(item));
+                        return Poll::Ready(Some(BatchItem::Packet(item)));
                     }
                     this.current = Current::Idle;
                 }
                 Current::Idle => match this.producers.pop_front() {
                     Some(Producer::SyncClosure(f)) => {
-                        return Poll::Ready(Some(f()));
+                        return Poll::Ready(Some(BatchItem::Packet(f())));
+                    }
+                    Some(Producer::StateChange(direction, new_state)) => {
+                        return Poll::Ready(Some(BatchItem::StateChange(direction, new_state)));
+                    }
+                    Some(Producer::EnableCompression) => {
+                        return Poll::Ready(Some(BatchItem::EnableCompression));
                     }
                     Some(Producer::AsyncClosure(f)) => {
                         this.current = Current::Future(f());
@@ -112,5 +150,49 @@ impl Stream for BatchStream {
                 },
             }
         }
+    }
+}
+
+#[cfg(test)]
+impl BatchItem {
+    pub fn unwrap_packet(&self) -> &PacketRegistry {
+        match self {
+            Self::Packet(packet) => packet,
+            Self::StateChange(direction, state) => panic!(
+                "tried to unwrap a packet, but got a state change instead direction={direction}, state={state}"
+            ),
+            Self::EnableCompression => {
+                panic!("tried to unwrap a packet, but got a compression instead")
+            }
+        }
+    }
+
+    pub fn unwrap_state_change(&self) -> (&Direction, &State) {
+        match self {
+            Self::StateChange(direction, state) => (direction, state),
+            Self::Packet(_) => panic!("tried to unwrap a packet, but got a packet instead"),
+            Self::EnableCompression => {
+                panic!("tried to unwrap a packet, but got a compression instead")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+impl BatchStream {
+    pub async fn assert_client_state(&mut self, state: State) {
+        use futures::StreamExt;
+        let v = self.next().await.unwrap();
+        let (direction, s) = v.unwrap_state_change();
+        assert_eq!(direction, &Direction::Clientbound);
+        assert_eq!(s, &state);
+    }
+
+    pub async fn assert_server_state(&mut self, state: State) {
+        use futures::StreamExt;
+        let v = self.next().await.unwrap();
+        let (direction, s) = v.unwrap_state_change();
+        assert_eq!(direction, &Direction::Serverbound);
+        assert_eq!(s, &state);
     }
 }

--- a/pico_limbo/src/server/batch.rs
+++ b/pico_limbo/src/server/batch.rs
@@ -1,23 +1,24 @@
+use crate::server::packet_registry::PacketRegistry;
 use futures::stream::Stream;
 use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-type AsyncClosure<T> =
-    Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = T> + Send>> + Send + 'static>;
+type AsyncClosure =
+    Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = PacketRegistry> + Send>> + Send + 'static>;
 
-enum Producer<T> {
-    SyncClosure(Box<dyn FnOnce() -> T + Send + 'static>),
-    AsyncClosure(AsyncClosure<T>),
-    Iterator(Box<dyn Iterator<Item = T> + Send + 'static>),
+enum Producer {
+    SyncClosure(Box<dyn FnOnce() -> PacketRegistry + Send + 'static>),
+    AsyncClosure(AsyncClosure),
+    Iterator(Box<dyn Iterator<Item = PacketRegistry> + Send + 'static>),
 }
 
-pub struct Batch<T> {
-    producers: VecDeque<Producer<T>>,
+pub struct Batch {
+    producers: VecDeque<Producer>,
 }
 
-impl<T: Send + 'static> Batch<T> {
+impl Batch {
     pub const fn new() -> Self {
         Self {
             producers: VecDeque::new(),
@@ -27,7 +28,7 @@ impl<T: Send + 'static> Batch<T> {
     /// Queues a synchronous function or closure.
     pub fn queue<F>(&mut self, f: F)
     where
-        F: FnOnce() -> T + Send + 'static,
+        F: FnOnce() -> PacketRegistry + Send + 'static,
     {
         self.producers.push_back(Producer::SyncClosure(Box::new(f)));
     }
@@ -36,9 +37,9 @@ impl<T: Send + 'static> Batch<T> {
     pub fn queue_async<F, Fut>(&mut self, f: F)
     where
         F: FnOnce() -> Fut + Send + 'static,
-        Fut: Future<Output = T> + Send + 'static,
+        Fut: Future<Output = PacketRegistry> + Send + 'static,
     {
-        let closure = move || -> Pin<Box<dyn Future<Output = T> + Send>> { Box::pin(f()) };
+        let closure = move || -> Pin<Box<dyn Future<Output = PacketRegistry> + Send>> { Box::pin(f()) };
         self.producers
             .push_back(Producer::AsyncClosure(Box::new(closure)));
     }
@@ -46,14 +47,14 @@ impl<T: Send + 'static> Batch<T> {
     /// Chains a synchronous iterator.
     pub fn chain_iter<I>(&mut self, iter: I)
     where
-        I: IntoIterator<Item = T>,
+        I: IntoIterator<Item = PacketRegistry>,
         I::IntoIter: Send + 'static,
     {
         self.producers
             .push_back(Producer::Iterator(Box::new(iter.into_iter())));
     }
 
-    pub fn into_stream(self) -> BatchStream<T> {
+    pub fn into_stream(self) -> BatchStream {
         BatchStream {
             producers: self.producers,
             current: Current::Idle,
@@ -61,19 +62,19 @@ impl<T: Send + 'static> Batch<T> {
     }
 }
 
-enum Current<T> {
+enum Current {
     Idle,
-    Future(Pin<Box<dyn Future<Output = T> + Send>>),
-    Iterator(Box<dyn Iterator<Item = T> + Send>),
+    Future(Pin<Box<dyn Future<Output = PacketRegistry> + Send>>),
+    Iterator(Box<dyn Iterator<Item = PacketRegistry> + Send>),
 }
 
-pub struct BatchStream<T> {
-    producers: VecDeque<Producer<T>>,
-    current: Current<T>,
+pub struct BatchStream {
+    producers: VecDeque<Producer>,
+    current: Current,
 }
 
-impl<T: Send + 'static> Stream for BatchStream<T> {
-    type Item = T;
+impl Stream for BatchStream {
+    type Item = PacketRegistry;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
@@ -111,28 +112,5 @@ impl<T: Send + 'static> Stream for BatchStream<T> {
                 },
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures::stream::StreamExt;
-
-    #[tokio::test]
-    async fn test_batch_stream() {
-        let mut batch = Batch::new();
-
-        batch.queue(|| 1);
-        batch.queue_async(|| async { 2 });
-        batch.chain_iter(3..5);
-
-        let mut stream = batch.into_stream();
-
-        assert_eq!(stream.next().await, Some(1));
-        assert_eq!(stream.next().await, Some(2));
-        assert_eq!(stream.next().await, Some(3));
-        assert_eq!(stream.next().await, Some(4));
-        assert_eq!(stream.next().await, None);
     }
 }

--- a/pico_limbo/src/server/client_data.rs
+++ b/pico_limbo/src/server/client_data.rs
@@ -15,10 +15,11 @@ pub struct ClientData {
     client_state: Arc<Mutex<ClientState>>,
     packet_stream: Arc<Mutex<PacketStream<TcpStream>>>,
     interval: Arc<Mutex<ControllableInterval>>,
+    keep_alive_interval: Duration,
 }
 
 impl ClientData {
-    pub fn new(socket: TcpStream) -> Self {
+    pub fn new(socket: TcpStream, keep_alive_interval: Duration) -> Self {
         let client_state = ClientState::default();
         let packet_stream = PacketStream::new(socket);
         let interval = ControllableInterval::new();
@@ -27,6 +28,7 @@ impl ClientData {
             client_state: Arc::new(Mutex::new(client_state)),
             packet_stream: Arc::new(Mutex::new(packet_stream)),
             interval: Arc::new(Mutex::new(interval)),
+            keep_alive_interval,
         }
     }
 
@@ -74,8 +76,10 @@ impl ClientData {
                 let period = Duration::from_secs(2);
                 self.interval().await.set_interval_at(start, period).await;
             } else {
-                let period = Duration::from_secs(15);
-                self.interval().await.set_interval(period).await;
+                self.interval()
+                    .await
+                    .set_interval(self.keep_alive_interval)
+                    .await;
             }
             self.client().await.set_keep_alive_enabled();
         }

--- a/pico_limbo/src/server/client_state.rs
+++ b/pico_limbo/src/server/client_state.rs
@@ -1,6 +1,6 @@
 use crate::server::game_profile::GameProfile;
 use minecraft_packets::login::Property;
-use minecraft_protocol::prelude::{ProtocolVersion, State, Uuid};
+use minecraft_protocol::prelude::{Direction, ProtocolVersion, State, Uuid};
 use tracing::info;
 
 #[derive(PartialEq, Eq)]
@@ -13,7 +13,8 @@ pub enum KeepAliveStatus {
 impl Default for ClientState {
     fn default() -> Self {
         Self {
-            state: State::Handshake,
+            clientbound_state: State::Handshake,
+            serverbound_state: State::Handshake,
             protocol_version: ProtocolVersion::Any,
             kick_message: None,
             message_id: -1,
@@ -28,7 +29,8 @@ impl Default for ClientState {
 }
 
 pub struct ClientState {
-    state: State,
+    clientbound_state: State,
+    serverbound_state: State,
     protocol_version: ProtocolVersion,
     kick_message: Option<String>,
     message_id: i32,
@@ -55,12 +57,23 @@ impl ClientState {
 
     // State
 
-    pub const fn state(&self) -> State {
-        self.state
+    pub const fn clientbound_state(&self) -> State {
+        self.clientbound_state
     }
 
-    pub const fn set_state(&mut self, new_state: State) {
-        self.state = new_state;
+    pub const fn serverbound_state(&self) -> State {
+        self.serverbound_state
+    }
+
+    pub const fn set_state(&mut self, direction: Direction, new_state: State) {
+        match direction {
+            Direction::Clientbound => {
+                self.clientbound_state = new_state;
+            }
+            Direction::Serverbound => {
+                self.serverbound_state = new_state;
+            }
+        }
     }
 
     // Protocol version

--- a/pico_limbo/src/server/controllable_interval.rs
+++ b/pico_limbo/src/server/controllable_interval.rs
@@ -26,19 +26,12 @@ impl ControllableInterval {
         }
     }
 
-    /// Disables the interval and sets a new one whose first tick fires after
-    /// `period`, then once per `period` after that.
-    ///
-    /// Note: we deliberately avoid `tokio::time::interval`'s default behaviour
-    /// of firing the first tick immediately. An immediate first tick races
-    /// against in-flight state transitions (e.g. CONFIGURATION -> PLAY), which
-    /// can cause a `keep_alive` packet to be sent with the wrong state's
-    /// packet ID on a client that has already advanced locally.
+    /// Disables the interval and sets a new one that starts ticking immediately.
     ///
     /// Any task currently waiting on `tick()` will be woken up and will
     /// start waiting for the new interval.
     pub async fn set_interval(&self, period: Duration) {
-        let mut new_interval = tokio::time::interval_at(Instant::now() + period, period);
+        let mut new_interval = tokio::time::interval(period);
         new_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         self.state.lock().await.interval = Some(new_interval);
         self.notify.notify_waiters();

--- a/pico_limbo/src/server/controllable_interval.rs
+++ b/pico_limbo/src/server/controllable_interval.rs
@@ -26,12 +26,19 @@ impl ControllableInterval {
         }
     }
 
-    /// Disables the interval and sets a new one that starts ticking immediately.
+    /// Disables the interval and sets a new one whose first tick fires after
+    /// `period`, then once per `period` after that.
+    ///
+    /// Note: we deliberately avoid `tokio::time::interval`'s default behaviour
+    /// of firing the first tick immediately. An immediate first tick races
+    /// against in-flight state transitions (e.g. CONFIGURATION -> PLAY), which
+    /// can cause a `keep_alive` packet to be sent with the wrong state's
+    /// packet ID on a client that has already advanced locally.
     ///
     /// Any task currently waiting on `tick()` will be woken up and will
     /// start waiting for the new interval.
     pub async fn set_interval(&self, period: Duration) {
-        let mut new_interval = tokio::time::interval(period);
+        let mut new_interval = tokio::time::interval_at(Instant::now() + period, period);
         new_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         self.state.lock().await.interval = Some(new_interval);
         self.notify.notify_waiters();

--- a/pico_limbo/src/server/network.rs
+++ b/pico_limbo/src/server/network.rs
@@ -1,3 +1,4 @@
+use crate::server::batch::{Batch, BatchItem};
 use crate::server::client_data::ClientData;
 use crate::server::packet_handler::{PacketHandler, PacketHandlerError};
 use crate::server::packet_registry::{
@@ -144,54 +145,88 @@ async fn process_packet(
     raw_packet: RawPacket,
     was_in_play_state: &mut bool,
 ) -> Result<(), PacketProcessingError> {
-    let mut client_state = client_data.client().await;
-    let protocol_version = client_state.protocol_version();
-    let state = client_state.state();
+    let (protocol_version, state) = {
+        let client_state = client_data.client().await;
+        (
+            client_state.protocol_version(),
+            client_state.serverbound_state(),
+        )
+    };
     let decoded_packet = PacketRegistry::decode_packet(protocol_version, state, raw_packet)?;
+    trace!(
+        packet_name = decoded_packet.packet_name(),
+        "Packet received"
+    );
 
-    let batch = {
+    let batch: Batch = {
         let server_state_guard = server_state.read().await;
+        let mut client_state = client_data.client().await;
         decoded_packet.handle(&mut client_state, &server_state_guard)?
     };
 
-    let protocol_version = client_state.protocol_version();
-    let state = client_state.state();
+    let (protocol_version, state) = {
+        let client_state = client_data.client().await;
+        (
+            client_state.protocol_version(),
+            client_state.serverbound_state(),
+        )
+    };
 
     if !*was_in_play_state && state == State::Play {
         *was_in_play_state = true;
         server_state.write().await.increment();
-        let username = client_state.get_username();
+        let username = {
+            let client_state = client_data.client().await;
+            client_state.get_username()
+        };
         debug!(
             "{} joined using version {}",
             username,
             protocol_version.humanize()
         );
-        info!("{} joined the game", username,);
+        info!("{} joined the game", username);
     }
 
     let mut stream = batch.into_stream();
     while let Some(pending_packet) = stream.next().await {
-        let enable_compression = matches!(pending_packet, PacketRegistry::SetCompression(..));
-        let raw_packet = pending_packet.encode_packet(protocol_version)?;
-        client_data.write_packet(raw_packet).await?;
-        if enable_compression
-            && let Some(compression_settings) = server_state.read().await.compression_settings()
-        {
-            let mut packet_stream = client_data.stream().await;
-            packet_stream
-                .set_compression(compression_settings.threshold, compression_settings.level);
+        match pending_packet {
+            BatchItem::Packet(packet) => {
+                trace!(packet_name = packet.packet_name(), "Sending packet");
+                let raw_packet = packet.encode_packet(protocol_version)?;
+                client_data.write_packet(raw_packet).await?;
+            }
+            BatchItem::StateChange(direction, new_state) => {
+                trace!(?direction, ?new_state, "Changing state");
+                let mut client_state = client_data.client().await;
+                client_state.set_state(direction, new_state);
+            }
+            BatchItem::EnableCompression => {
+                if let Some(compression_settings) = server_state.read().await.compression_settings()
+                {
+                    let mut packet_stream = client_data.stream().await;
+                    packet_stream.set_compression(
+                        compression_settings.threshold,
+                        compression_settings.level,
+                    );
+                } else {
+                    warn!("compression enabled but no settings were found");
+                }
+            }
         }
     }
 
-    if let Some(reason) = client_state.should_kick() {
-        drop(client_state);
+    let should_kick = {
+        let client_state = client_data.client().await;
+        client_state.should_kick()
+    };
+
+    if let Some(reason) = should_kick {
         kick_client(client_data, reason.clone())
             .await
             .map_err(|_| PacketProcessingError::Disconnected)?;
         return Err(PacketProcessingError::Disconnected);
     }
 
-    drop(client_state);
     client_data.enable_keep_alive_if_needed().await;
 
     Ok(())
@@ -252,7 +287,7 @@ async fn kick_client(
 ) -> Result<(), PacketProcessingError> {
     let (protocol_version, state) = {
         let state = client_data.client().await;
-        (state.protocol_version(), state.state())
+        (state.protocol_version(), state.clientbound_state())
     };
     let packet = match state {
         State::Login => {
@@ -283,7 +318,7 @@ async fn kick_client(
 async fn send_keep_alive(client_data: &ClientData) -> Result<(), PacketProcessingError> {
     let (protocol_version, state) = {
         let client = client_data.client().await;
-        (client.protocol_version(), client.state())
+        (client.protocol_version(), client.clientbound_state())
     };
 
     let packet = match state {
@@ -297,6 +332,7 @@ async fn send_keep_alive(client_data: &ClientData) -> Result<(), PacketProcessin
     };
 
     if let Some(packet) = packet {
+        trace!(?state, "sending keep alive");
         let raw_packet = packet.encode_packet(protocol_version)?;
         client_data.write_packet(raw_packet).await?;
     }

--- a/pico_limbo/src/server/network.rs
+++ b/pico_limbo/src/server/network.rs
@@ -214,7 +214,8 @@ async fn read(
 }
 
 async fn handle_client(socket: TcpStream, server_state: Arc<RwLock<ServerState>>) {
-    let client_data = ClientData::new(socket);
+    let keep_alive_interval = server_state.read().await.keep_alive_interval();
+    let client_data = ClientData::new(socket, keep_alive_interval);
     let mut was_in_play_state = false;
 
     loop {
@@ -284,8 +285,17 @@ async fn send_keep_alive(client_data: &ClientData) -> Result<(), PacketProcessin
         (client.protocol_version(), client.state())
     };
 
-    if state == State::Play {
-        let packet = PacketRegistry::ClientBoundKeepAlive(ClientBoundKeepAlivePacket::random()?);
+    let packet = match state {
+        State::Configuration => Some(PacketRegistry::ConfigurationClientBoundKeepAlive(
+            ClientBoundKeepAlivePacket::random()?,
+        )),
+        State::Play => Some(PacketRegistry::ClientBoundKeepAlive(
+            ClientBoundKeepAlivePacket::random()?,
+        )),
+        _ => None,
+    };
+
+    if let Some(packet) = packet {
         let raw_packet = packet.encode_packet(protocol_version)?;
         client_data.write_packet(raw_packet).await?;
     }

--- a/pico_limbo/src/server/network.rs
+++ b/pico_limbo/src/server/network.rs
@@ -215,7 +215,8 @@ async fn read(
 }
 
 async fn handle_client(socket: TcpStream, server_state: Arc<RwLock<ServerState>>) {
-    let client_data = ClientData::new(socket);
+    let keep_alive_interval = server_state.read().await.keep_alive_interval();
+    let client_data = ClientData::new(socket, keep_alive_interval);
     let mut was_in_play_state = false;
 
     loop {
@@ -285,8 +286,17 @@ async fn send_keep_alive(client_data: &ClientData) -> Result<(), PacketProcessin
         (client.protocol_version(), client.state())
     };
 
-    if state == State::Play {
-        let packet = PacketRegistry::ClientBoundKeepAlive(ClientBoundKeepAlivePacket::random()?);
+    let packet = match state {
+        State::Configuration => Some(PacketRegistry::ConfigurationClientBoundKeepAlive(
+            ClientBoundKeepAlivePacket::random()?,
+        )),
+        State::Play => Some(PacketRegistry::ClientBoundKeepAlive(
+            ClientBoundKeepAlivePacket::random()?,
+        )),
+        _ => None,
+    };
+
+    if let Some(packet) = packet {
         let raw_packet = packet.encode_packet(protocol_version)?;
         client_data.write_packet(raw_packet).await?;
     }

--- a/pico_limbo/src/server/packet_handler.rs
+++ b/pico_limbo/src/server/packet_handler.rs
@@ -1,6 +1,5 @@
 use crate::server::batch::Batch;
 use crate::server::client_state::ClientState;
-use crate::server::packet_registry::PacketRegistry;
 use crate::server_state::ServerState;
 use thiserror::Error;
 

--- a/pico_limbo/src/server/packet_handler.rs
+++ b/pico_limbo/src/server/packet_handler.rs
@@ -40,7 +40,7 @@ pub trait PacketHandler {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError>;
+    ) -> Result<Batch, PacketHandlerError>;
 }
 
 impl From<pico_registries::Error> for PacketHandlerError {

--- a/pico_limbo/src/server/packet_registry.rs
+++ b/pico_limbo/src/server/packet_registry.rs
@@ -185,6 +185,13 @@ pub enum PacketRegistry {
     #[protocol_id(
         state = "configuration",
         bound = "clientbound",
+        name = "minecraft:keep_alive"
+    )]
+    ConfigurationClientBoundKeepAlive(ClientBoundKeepAlivePacket),
+
+    #[protocol_id(
+        state = "configuration",
+        bound = "clientbound",
         name = "minecraft:finish_configuration"
     )]
     FinishConfiguration(FinishConfigurationPacket),

--- a/pico_limbo/src/server/packet_registry.rs
+++ b/pico_limbo/src/server/packet_registry.rs
@@ -373,7 +373,7 @@ impl PacketHandler for PacketRegistry {
         &self,
         client_state: &mut ClientState,
         server_state: &ServerState,
-    ) -> Result<Batch<PacketRegistry>, PacketHandlerError> {
+    ) -> Result<Batch, PacketHandlerError> {
         match self {
             Self::Handshake(packet) => packet.handle(client_state, server_state),
             Self::StatusRequest(packet) => packet.handle(client_state, server_state),

--- a/pico_limbo/src/server/packet_registry.rs
+++ b/pico_limbo/src/server/packet_registry.rs
@@ -193,6 +193,13 @@ pub enum PacketRegistry {
     #[protocol_id(
         state = "configuration",
         bound = "clientbound",
+        name = "minecraft:keep_alive"
+    )]
+    ConfigurationClientBoundKeepAlive(ClientBoundKeepAlivePacket),
+
+    #[protocol_id(
+        state = "configuration",
+        bound = "clientbound",
         name = "minecraft:finish_configuration"
     )]
     FinishConfiguration(FinishConfigurationPacket),

--- a/pico_limbo/src/server/start_server.rs
+++ b/pico_limbo/src/server/start_server.rs
@@ -121,6 +121,7 @@ fn build_state(cfg: Config) -> Result<ServerState, ServerStateBuilderError> {
         .view_distance(cfg.world.experimental.view_distance)
         .schematic(cfg.world.experimental.schematic_file)
         .enable_compression(cfg.compression.threshold, cfg.compression.level)?
+        .keep_alive_interval_secs(cfg.keep_alive_interval_seconds)
         .fetch_player_skins(cfg.fetch_player_skins)
         .reduced_debug_info(cfg.reduced_debug_info)
         .set_player_listed(cfg.tab_list.player_listed)

--- a/pico_limbo/src/server/start_server.rs
+++ b/pico_limbo/src/server/start_server.rs
@@ -126,6 +126,7 @@ fn build_state(cfg: Config) -> Result<ServerState, ServerStateBuilderError> {
         .view_distance(cfg.world.experimental.view_distance)
         .schematic(cfg.world.experimental.schematic_file)
         .enable_compression(cfg.compression.threshold, cfg.compression.level)?
+        .keep_alive_interval_secs(cfg.keep_alive_interval_seconds)
         .fetch_player_skins(cfg.fetch_player_skins)
         .reduced_debug_info(cfg.reduced_debug_info)
         .set_player_listed(cfg.tab_list.player_listed)

--- a/pico_limbo/src/server_state/mod.rs
+++ b/pico_limbo/src/server_state/mod.rs
@@ -111,6 +111,7 @@ pub struct ServerState {
     allow_unsupported_versions: bool,
     allow_flight: bool,
     server_commands: ServerCommands,
+    keep_alive_interval_secs: u64,
 }
 
 impl ServerState {
@@ -192,6 +193,13 @@ impl ServerState {
 
     pub const fn view_distance(&self) -> i32 {
         self.view_distance
+    }
+
+    /// Keep-alive interval used for clients on 1.8+ (CONFIGURATION + PLAY).
+    /// Clients <= 1.7.6 use a hard-coded 2-second period required by the
+    /// legacy protocol, independent of this value.
+    pub const fn keep_alive_interval(&self) -> Duration {
+        Duration::from_secs(self.keep_alive_interval_secs)
     }
 
     pub fn world(&self) -> Option<Arc<World>> {
@@ -303,6 +311,7 @@ pub struct ServerStateBuilder {
     allow_flight: bool,
     accept_transfers: bool,
     server_commands: ServerCommands,
+    keep_alive_interval_secs: Option<u64>,
 }
 
 #[derive(Debug, Error)]
@@ -453,6 +462,13 @@ impl ServerStateBuilder {
 
     pub fn view_distance(&mut self, view_distance: i32) -> &mut Self {
         self.view_distance = view_distance.max(0);
+        self
+    }
+
+    /// Set the keep-alive interval, in seconds, for clients on 1.8+.
+    /// Defaults to 15 (vanilla) when this method is not called.
+    pub const fn keep_alive_interval_secs(&mut self, secs: u64) -> &mut Self {
+        self.keep_alive_interval_secs = Some(secs);
         self
     }
 
@@ -619,6 +635,7 @@ impl ServerStateBuilder {
             allow_flight: self.allow_flight,
             accept_transfers: self.accept_transfers,
             server_commands: self.server_commands,
+            keep_alive_interval_secs: self.keep_alive_interval_secs.unwrap_or(15),
         })
     }
 }


### PR DESCRIPTION
If a client sits in CONFIGURATION state for more than 30s (e.g. behind a custom auth / registration dialog held server-side) Velocity and most proxies drops it w/ `[connected player] read timed out`. Velocity's default read-timeout is 30s and PicoLimbo wasn't sending any keep-alive until PLAY, so nothing kept the connection warm during a long hold.

### Root cause
`send_keep_alive` in `pico_limbo/src/server/network.rs` only fired in `State::Play`

Vanilla / mojmap-side, `minecraft:keep_alive` is a legit clientbound packet in CONFIGURATION state too, same wire shape, just a different protocol ID per version (resolved automatically by the `PacketReport` macro from the data reports).

### Fix
- New variant `PacketRegistry::ConfigurationClientBoundKeepAlive(ClientBoundKeepAlivePacket)` w/ `state = "configuration"` / `bound = "clientbound"` / `name = "minecraft:keep_alive"`. Reuses the existing play packet struct since the wire format is identical.
- `send_keep_alive` now dispatches on `client.state()`: `Configuration` -> emits the new variant, `Play` -> emits the existing one, anything else -> no-op.
- `LoginAcknowledgedPacket` calls `client_state.set_keep_alive_should_enable()` right after `set_state(Configuration)`. The ticker arms on the next `enable_keep_alive_if_needed()` (end of `process_packet`), same machinery PLAY already uses.

The interval is also made user-configurable while we're here: new top-level TOML option `keep_alive_interval_seconds` (default `15`, matching vanilla). It flows from `Config` -> `ServerStateBuilder::keep_alive_interval_secs` -> `ServerState::keep_alive_interval()` -> `ClientData::new` so each connection picks up the configured value at construction time. The 2-second period for 1.7.6- clients stays hard-coded since it's a protocol requirement, not a tunable.

### Test
- `test_login_ack_supported_protocol` tightened to assert `client_state.should_enable_keep_alive()` after the handler runs, so a regression of "ticker armed in CONFIG" is caught at the unit level.
- All 4 existing `login_acknowledged` tests still pass.

E2E I ran locally: Velocity 3.5.x + PacketEvents 2.12.1 + a 26.1.2 client + a custom CONFIG-state hold of  around 60s. Before: `read timed out` after 30s. After: connection stays up, PE plugins see the keep-alive flow, no Velocity log noise.

### Scope / risk
- No protocol-version gating beyond the existing `supports_configuration_state()` check. The `keep_alive` clientbound report is defined in `configuration` for every version of the repo that supports CONFIG state (1.20.2 → 26.1).
- Vanilla-equivalent default behaviour: with the default `keep_alive_interval_seconds = 15`, this matches what a vanilla server does in CONFIG state.
