### PR TITLE
switch entity id to 1

### DIFF
--- a/crates/minecraft_packets/src/play/login_packet.rs
+++ b/crates/minecraft_packets/src/play/login_packet.rs
@@ -88,7 +88,7 @@ impl LoginPacket {
     /// This is the constructor for all versions from 1.7.2 to 1.15.2 included
     pub fn with_dimension_pre_v1_16(dimension: Dimension) -> Self {
         Self {
-            entity_id: 0,
+            entity_id: 1,
             data: LoginPacketData::PreV1_16(PreV1_16Data {
                 dimension: DimensionField(dimension.legacy_i8()),
                 ..PreV1_16Data::default()


### PR DESCRIPTION
fixes several client side bugs that occur on backends when a pre 1.16 player has an entity id of 0, like broken firework elytra boosting https://bugs.mojang.com/browse/MC/issues/MC-111480 

this only affects bungee networks that use picolimbo as the first server players join (like an auth server). sub 1.16 clients switch servers from a respawn packet instead of a login packet which means the player's entity id never gets updated. so whatever entity id picolimbo assigns will stick on the client for their entire session across all backend servers, which will cause these bugs everywhere else.