### PR TITLE
fix: do not send Registry Data for registries without entries

### DIFF
--- a/pico_libraries/pico_registries/src/data/registry.rs
+++ b/pico_libraries/pico_registries/src/data/registry.rs
@@ -52,6 +52,16 @@ impl Registry {
         entries
     }
 
+    /// Whether this registry holds any entry.
+    ///
+    /// A registry can end up empty because [`Self::load`] falls back to an empty
+    /// map when no entry directory exists, which happens for registries that are
+    /// only mapped to carry tags (for example `minecraft:block`).
+    #[must_use]
+    pub fn has_entries(&self) -> bool {
+        !self.entries.is_empty()
+    }
+
     #[must_use]
     pub const fn get_registry_key(&self) -> &RegistryKey {
         &self.key

--- a/pico_libraries/pico_registries/src/registry_provider/registry_data_v1_20_5.rs
+++ b/pico_libraries/pico_registries/src/registry_provider/registry_data_v1_20_5.rs
@@ -34,6 +34,11 @@ pub fn get_registry_data_v1_20_5(
     Ok(registries
         .iter()
         .filter_map(|registry_keys| registry_manager.try_get(registry_keys))
+        // Registries that only exist to carry tags have no entry directory and load
+        // empty. Sending an empty Registry Data packet for them carries no
+        // information, and clients that do not expect the registry to be synced at
+        // all can fail hard on it (Geyser throws on `minecraft:block`).
+        .filter(|registry| registry.has_entries())
         .map(|registry| {
             let registry_entries = registry
                 .get_entries()


### PR DESCRIPTION
`minecraft:block` is mapped as a mandatory registry from 26.2 onwards so that block tags can be sent. It has no entry directory in the generated data, and `Registry::load` falls back to an empty entry map instead of failing, so the registry still ends up in the RegistryManager.

As a result an empty Registry Data packet is emitted for `minecraft:block` during configuration. It carries no information, and clients that do not expect that registry to be synced can fail hard on it: Geyser (and therefore every Bedrock player behind it) dies with

    IllegalStateException: Expected reader for registry
    Java registry: minecraft:block

Vanilla clients silently ignore the packet, which is why this went unnoticed.

Skip registries without entries when building the Registry Data packets. Tags are unaffected: `get_tagged_registries()` keeps its own list and still emits block tags.