### PR TITLE
fix: do not send Registry Data for registries without entries

### DIFF
--- a/pico_libraries/pico_registries/src/data/registry.rs
+++ b/pico_libraries/pico_registries/src/data/registry.rs
@@ -52,6 +52,16 @@ impl Registry {
         entries
     }
 
+    /// Whether this registry holds any entry.
+    ///
+    /// A registry can end up empty because [`Self::load`] falls back to an empty
+    /// map when no entry directory exists, which happens for registries that are
+    /// only mapped to carry tags (for example `minecraft:block`).
+    #[must_use]
+    pub fn has_entries(&self) -> bool {
+        !self.entries.is_empty()
+    }
+
     #[must_use]
     pub const fn get_registry_key(&self) -> &RegistryKey {
         &self.key

--- a/pico_libraries/pico_registries/src/registry_provider/registry_data_v1_20_5.rs
+++ b/pico_libraries/pico_registries/src/registry_provider/registry_data_v1_20_5.rs
@@ -34,6 +34,11 @@ pub fn get_registry_data_v1_20_5(
     Ok(registries
         .iter()
         .filter_map(|registry_keys| registry_manager.try_get(registry_keys))
+        // Registries that only exist to carry tags have no entry directory and load
+        // empty. Sending an empty Registry Data packet for them carries no
+        // information, and clients that do not expect the registry to be synced at
+        // all can fail hard on it (Geyser throws on `minecraft:block`).
+        .filter(|registry| registry.has_entries())
         .map(|registry| {
             let registry_entries = registry
                 .get_entries()


### PR DESCRIPTION
# Do not send Registry Data for registries without entries

## Problem

Bedrock players connecting through Geyser are disconnected during the configuration phase:

```
java.lang.IllegalStateException: Expected reader for registry Java registry: minecraft:block
    at org.geysermc.geyser.session.cache.RegistryCache.load(RegistryCache.java:158)
    at org.geysermc.geyser.translator.protocol.java.JavaRegistryDataTranslator.translate(...)
```

Vanilla Java clients ignore the packet in question, so this only shows up with clients that are stricter about what they receive.

## Cause

`minecraft:block` is mapped as a mandatory registry from 26.2 onwards (`RegistryKeys::Block`) so that block tags can be sent. It is not datapack driven though, so there is no `data/minecraft/block` directory to load entries from. `Registry::load` falls back to an empty entry map rather than failing:

```rust
let entries = Self::load_entries(registry_keys, resource_path).unwrap_or_default();
```

The registry therefore ends up in the `RegistryManager` with zero entries, and `get_registry_data_v1_20_5` emits a Registry Data packet for it. That packet carries no information, and a client that does not expect `minecraft:block` to be synced at all can treat it as a protocol error.

## Change

Skip registries that hold no entries when building the Registry Data packets. Tags are not affected: `get_tagged_registries` keeps its own list and still emits block tags.

## Tested versions

* **26.2**, with a Bedrock 26.40 client through Geyser 2.11.1-b1208, and with a vanilla Java 26.2 client. Before the change every Bedrock join failed on the registry packet, after it the configuration phase completes. Java behaviour is unchanged.
* **1.21.11**, vanilla Java client, no behaviour change observed. This version is unaffected in the first place since its dataset has no entryless mandatory registry.
* Versions below 1.21.11 were **not** tested. The change only skips registries that would have produced an empty packet, so older versions should be unaffected, but I cannot confirm that from testing.

## AI usage

I used Claude Code while investigating this. It helped me read through the registry loading path and narrow down where the empty packet came from, and it drafted the code and this description. I reviewed every line, ran the builds, and did all the client side testing myself. Happy to walk through the implementation in review.
