### PR TITLE
fix: resolve tag contents through the generated registries report

### DIFF
--- a/pico_libraries/pico_registries/src/data/registry.rs
+++ b/pico_libraries/pico_registries/src/data/registry.rs
@@ -16,6 +16,16 @@ pub struct Registry {
     key: RegistryKey,
     /// Name of the tag mapped to the tag
     tags: HashMap<Identifier, Tag>,
+    /// Protocol IDs taken from `reports/registries.json`.
+    ///
+    /// Not every registry is datapack driven, so not every registry has an entry
+    /// directory to load from. `minecraft:block` is the prominent one. Those
+    /// entries never make it into `entries`, and tags pointing at them cannot be
+    /// resolved from there. The generated report knows every entry of every
+    /// registry together with its real protocol ID, which is exactly what tags
+    /// need.
+    #[serde(skip_serializing)]
+    report_protocol_ids: HashMap<Identifier, u32>,
 }
 
 impl Registry {
@@ -38,11 +48,33 @@ impl Registry {
     ///
     /// # Errors
     /// Returns an error if it fails to load a registry
-    pub fn load(registry_keys: &RegistryKeys, resource_path: &Path) -> crate::Result<Self> {
+    pub fn load(
+        registry_keys: &RegistryKeys,
+        resource_path: &Path,
+        report_protocol_ids: HashMap<Identifier, u32>,
+    ) -> crate::Result<Self> {
         let entries = Self::load_entries(registry_keys, resource_path).unwrap_or_default();
         let tags = Self::load_tags(registry_keys, resource_path).unwrap_or_default();
         let key = RegistryKey::of_registry(registry_keys.id());
-        Ok(Self { entries, key, tags })
+        Ok(Self {
+            entries,
+            key,
+            tags,
+            report_protocol_ids,
+        })
+    }
+
+    /// Protocol ID of an entry, falling back to the generated registries report.
+    ///
+    /// Loaded entries win so datapack driven registries keep the IDs derived from
+    /// their directory order; the report only fills in registries that have no
+    /// entry directory at all.
+    #[must_use]
+    pub fn protocol_id_of(&self, registry_ref: &Identifier) -> Option<u32> {
+        self.entries
+            .get(registry_ref)
+            .map(RegistryEntry::get_protocol_id)
+            .or_else(|| self.report_protocol_ids.get(registry_ref).copied())
     }
 
     #[must_use]

--- a/pico_libraries/pico_registries/src/data/registry_manager.rs
+++ b/pico_libraries/pico_registries/src/data/registry_manager.rs
@@ -1,5 +1,6 @@
 use crate::data::registry::Registry;
 use crate::registry_keys::RegistryKeys;
+use crate::reports::registries_report::RegistriesReport;
 use std::collections::HashMap;
 use std::path::Path;
 use tracing::debug;
@@ -60,11 +61,36 @@ impl RegistryManagerBuilder {
     #[must_use]
     pub fn load_from_resource_path(self, resource_path: &Path) -> RegistryManager {
         let data_path = resource_path.join("data");
+
+        // Parsed once for the whole manager, not per registry - the report is a
+        // few hundred kilobytes. Missing or unreadable reports are not fatal:
+        // registries that have an entry directory work without it, only tags on
+        // directory-less registries lose their IDs.
+        let report = RegistriesReport::from_resource_path(resource_path).map_or_else(
+            |error| {
+                debug!(?error, "Failed to load registries report, continuing without");
+                None
+            },
+            Some,
+        );
+
         let registries = self
             .registry_keys
             .iter()
             .filter_map(|registry_key| {
-                Registry::load(registry_key, &data_path).map_or_else(
+                let report_protocol_ids = report
+                    .as_ref()
+                    .and_then(|report| report.registries.get(&registry_key.id()))
+                    .map(|registry| {
+                        registry
+                            .entries
+                            .iter()
+                            .map(|(identifier, entry)| (identifier.clone(), entry.protocol_id))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                Registry::load(registry_key, &data_path, report_protocol_ids).map_or_else(
                     |_| {
                         debug!(
                             registry_key = ?registry_key,

--- a/pico_libraries/pico_registries/src/registry_provider/tagged_registries.rs
+++ b/pico_libraries/pico_registries/src/registry_provider/tagged_registries.rs
@@ -1,4 +1,3 @@
-use crate::data::registry_entry::RegistryEntry;
 use crate::{Registry, RegistryKeys, RegistryManager};
 use pico_identifier::Identifier;
 use std::borrow::Cow;
@@ -58,11 +57,7 @@ fn evaluate_tags(registry: &Registry, tag_name: &Identifier) -> crate::Result<Ve
                 evaluate_tags(registry, &identifier.normalize())
             } else {
                 // If it is not a tag, then we should get the protocol ID of the actual value from the registry
-                Ok(registry
-                    .try_get(identifier)
-                    .into_iter()
-                    .map(RegistryEntry::get_protocol_id)
-                    .collect())
+                Ok(registry.protocol_id_of(identifier).into_iter().collect())
             }
         })
         .flatten()

--- a/pico_libraries/pico_registries/src/reports/registries_report.rs
+++ b/pico_libraries/pico_registries/src/reports/registries_report.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::path::Path;
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)] // TODO: This is currently unused, but should become used later on
 pub struct RegistriesReport {
     #[serde(flatten)]
     pub registries: HashMap<Identifier, Registry>,
@@ -12,23 +11,24 @@ pub struct RegistriesReport {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(dead_code)] // TODO: This is currently unused, but should become used later on
 pub struct Registry {
+    // Both are only here because `deny_unknown_fields` requires every key of the
+    // report to be modelled; nothing reads them yet.
     #[serde(default)]
+    #[allow(dead_code)]
     pub default: Option<String>,
     pub entries: HashMap<Identifier, Entry>,
+    #[allow(dead_code)]
     pub protocol_id: u32,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(dead_code)] // TODO: This is currently unused, but should become used later on
 pub struct Entry {
     pub protocol_id: u32,
 }
 
 impl RegistriesReport {
-    #[allow(dead_code)] // TODO: This is currently unused, but should become used later on
     pub fn from_resource_path(resource_path: &Path) -> crate::Result<Self> {
         let registries_report_path = resource_path.join("reports").join("registries.json");
         let json_str = std::fs::read_to_string(&registries_report_path)?;


### PR DESCRIPTION
# Resolve tag contents through the generated registries report

## Problem

Every block tag PicoLimbo sends arrives at the client as an empty ID list. `minecraft:mineable/axe`, `minecraft:climbable` and the rest are all transmitted with no contents.

Vanilla clients shrug that off, but clients that act on tag contents are actively misinformed rather than merely uninformed. Geyser for example derives its block prediction behaviour from these tags:

```
Emulating post 1.18 block predication logic for <player>? false
```

Against a Paper server the same Geyser build reports `true`.

## Cause

`evaluate_tags` resolves tag contents against the entries of the registry the tag belongs to:

```rust
Ok(registry.try_get(identifier).into_iter()
    .map(RegistryEntry::get_protocol_id).collect())
```

Those entries come from the datapack directory. Not every registry is datapack driven though, so not every registry has one. `minecraft:block` is the prominent case: mapped from 26.2 onwards so block tags can be sent, but with no `data/minecraft/block` directory to load from, so `Registry::load` falls back to an empty entry map. Every lookup in `evaluate_tags` then misses.

## Change

The data needed to fix this is already in the tree. `reports/registries.json` lists every entry of every registry with its real protocol ID, and `RegistriesReport` already parses it. It was never wired up, hence the `TODO: This is currently unused, but should become used later on` markers on the struct.

This loads the report once per `RegistryManager` and uses it as a fallback in `Registry::protocol_id_of` when an identifier is not among the loaded entries.

Deliberate properties of the change:

* **Loaded entries keep precedence.** Datapack driven registries continue to use the IDs derived from their directory order, so nothing about their behaviour changes.
* **A missing or unreadable report is not fatal.** It is parsed once, failures are logged at debug level and the manager continues. Only tags on registries without an entry directory lose their IDs, which is exactly the current behaviour.
* **Parsed once per manager, not per registry**, since the report is a few hundred kilobytes.

## Tested versions

* **26.2**, with a Bedrock 26.40 client through Geyser 2.11.1-b1208, and with a vanilla Java 26.2 client. Geyser now reports `Emulating post 1.18 block predication logic ... ? true`, matching what it reports against Paper. Java behaviour is unchanged.
* **1.21.11**, vanilla Java client, no behaviour change observed. That dataset has no entryless registry, so the fallback never triggers there.
* Versions below 1.21.11 were **not** tested. The fallback only applies where a lookup misses today, so older versions should be unaffected, but I cannot confirm that from testing.

`cargo build --release` is warning free.

## Unrelated observation

While tracking this down I noticed `data/generated/V26_2/data/minecraft/tags/` ships `block`, `banner_pattern` and `damage_type`, while `V1_21_11` only has `dialog` and `timeline`. `REGISTRIES_TO_SEND` in `data/src/clean/cleanData.ts` only lists `tags/dialog` and `tags/timeline`, so the 26.2 dataset looks like it was not run through the cleaning step. Not touched here since the tag data itself is correct and useful, but it might be worth a look.

## AI usage

I used Claude Code while investigating this. It helped me trace the tag resolution path, spot the unused `RegistriesReport`, and it drafted the code and this description. I reviewed every line, ran the builds, and did all the client side testing myself. Happy to walk through the implementation in review.
